### PR TITLE
Mac build fails because brew upgrade python fails

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -76,10 +76,7 @@ jobs:
 
       - name: Install SDL2
         run: |
-          brew unlink python
-          brew unlink python@3
-          brew unlink python@3.10
-          brew unlink python@3.11
+          brew pin python
           brew update
           brew upgrade
           brew install sdl2 sdl2_image

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -76,11 +76,11 @@ jobs:
 
       - name: Install SDL2
         run: |
-          brew update
           brew unlink python
           brew unlink python@3
           brew unlink python@3.10
           brew unlink python@3.11
+          brew update
           brew upgrade
           brew install sdl2 sdl2_image
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -76,9 +76,6 @@ jobs:
 
       - name: Install SDL2
         run: |
-          brew pin python
-          brew update
-          brew upgrade
           brew install sdl2 sdl2_image
 
       - name: Configure CMake


### PR DESCRIPTION
Brew fails installing SDL2 because some dependency require brew to update python (3.10 and 3.11) but that fails because of some linking error.