### PR TITLE
API should be as independent of the underlying graphics engine as possible.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(remotemo
     VERSION 0.1.0
     LANGUAGES CXX
 )
-set(remotemo_PRE_RELEASE_LABEL alpha.0)
+set(remotemo_PRE_RELEASE_LABEL beta.0)
 
 if(NOT remotemo_PRE_RELEASE_LABEL STREQUAL "")
     set(remotemo_VERSION

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(remotemo
     VERSION 0.1.0
     LANGUAGES CXX
 )
-set(remotemo_PRE_RELEASE_LABEL beta.1)
+set(remotemo_PRE_RELEASE_LABEL beta.2)
 
 if(NOT remotemo_PRE_RELEASE_LABEL STREQUAL "")
     set(remotemo_VERSION

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(remotemo
     VERSION 0.1.0
     LANGUAGES CXX
 )
-set(remotemo_PRE_RELEASE_LABEL beta.0)
+set(remotemo_PRE_RELEASE_LABEL beta.1)
 
 if(NOT remotemo_PRE_RELEASE_LABEL STREQUAL "")
     set(remotemo_VERSION

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The easiest way to start using remoTemo is to simply call
 `remotemo::create()`, check its return status and then you can start
 calling the text-input/output methods of the object created.
 
-```C++
+```cpp
 #include <remotemo/remotemo.hpp>
 
 int main(int argc, char* argv[])

--- a/docs/API_design.md
+++ b/docs/API_design.md
@@ -45,7 +45,7 @@ In short:
 
 The library provides a few functions that returns its name and its version:
 
-```C++
+```cpp
 std::string remotemo::full_name();
 std::string remotemo::version_full();
 int remotemo::version_major();
@@ -79,7 +79,7 @@ Assuming the version to be `1.1.0-beta.2`, they would return the following:
 ## Initialization, cleanup and config
 ### Initialization
 
-```C++
+```cpp
 std::optional<remotemo::Remotemo> remotemo::create();
 std::optional<remotemo::Remotemo> remotemo::create(
         const remotemo::Config& config);
@@ -128,7 +128,7 @@ Idiom](https://isocpp.org/wiki/faq/ctors#named-parameter-idiom) is followed,
 providing you with a "config" object that when created, will contains the
 default initialization settings:
 
-```C++
+```cpp
 remotemo::Config::Config();
 ```
 
@@ -141,7 +141,7 @@ everything with the settings you wanted.
 - You can store that `remotemo::Config` object in a variable, work on it and
   then pass it to `remotemo::create()`:
 
-  ```C++
+  ```cpp
   remotemo::Config my_config;
   if (some_condition) {
       my_config.window_size(1920, 1080);
@@ -154,7 +154,7 @@ everything with the settings you wanted.
 - Or you could simply call `remotemo::create()` directly with a temporary
   `remotemo::Config` object:
   
-  ```C++
+  ```cpp
   auto text_monitor = remotemo::create(
           remotemo::Config()
                   .window_size(1920, 1080)
@@ -165,7 +165,7 @@ everything with the settings you wanted.
 <sup>[Back to top](#remotemo-api-design)</sup>
 ### Cleanup
 
-```C++
+```cpp
 remotemo::Remotemo::~Remotemo();
 ```
 
@@ -190,7 +190,7 @@ renderer, the window and quitting SDL._
 
 If, for some reason, you want to clean up sooner, you could call:
 
-```C++
+```cpp
 void remotemo::Remotemo::quit();
 ```
 This will just close the window and clean up its resources.
@@ -209,7 +209,7 @@ Unless noted, the settings can not be changed after the `remotemo::Remotemo`
 object has been created:
 
 - Cleanup all: `true`
-  ```C++
+  ```cpp
   remotemo::Config& remotemo::Config::cleanup_all(bool cleanup_all);
   ```
   - If `true`, then the destructor of the `remotemo::Remotemo` object will
@@ -226,7 +226,7 @@ object has been created:
     and quit SDL afterwards yourself.
 
 - Window: `nullptr`
-  ```C++
+  ```cpp
   remotemo::Config& remotemo::Config::window(SDL_Window* window);
   ```
   - If set to `nullptr` then `remotemo::create()` will create the window with
@@ -240,12 +240,14 @@ object has been created:
     - resizable: `true` _(can be changed later)_
     - fullscreen: `false` _(can be changed later)_
 
-    ```C++
+    ```cpp
     remotemo::Config& remotemo::Config::window_title(const std::string& title);
     remotemo::Config& remotemo::Config::window_size(int width, int height);
-    remotemo::Config& remotemo::Config::window_size(const SDL_Point& size);
+    remotemo::Config& remotemo::Config::window_size(
+            const remotemo::Size& size);
     remotemo::Config& remotemo::Config::window_position(int x, int y);
-    remotemo::Config& remotemo::Config::window_position(const SDL_Point& pos);
+    remotemo::Config& remotemo::Config::window_position(
+            const remotemo::Point& pos);
     remotemo::Config& remotemo::Config::window_resizable(bool is_resizable);
     remotemo::Config& remotemo::Config::window_fullscreen(bool is_fullscreen);
     ```
@@ -271,7 +273,7 @@ object has been created:
   default):
   - Key to switch between fullscreen and windowed mode: `F11` _(can be changed
     later)_
-    ```C++
+    ```cpp
     remotemo::Config& remotemo::Config::key_fullscreen(); // Set to none
     remotemo::Config& remotemo::Config::key_fullscreen(
             remotemo::Mod_keys modifier_keys, remotemo::F_key key);
@@ -279,7 +281,7 @@ object has been created:
             remotemo::Mod_keys_strict modifier_keys, remotemo::Key key);
     ```
   - Key combination to close the window: `Ctrl-w` _(can be changed later)_
-    ```C++
+    ```cpp
     remotemo::Config& remotemo::Config::key_close_window(); // Set to none
     remotemo::Config& remotemo::Config::key_close_window(
             remotemo::Mod_keys modifier_keys, remotemo::F_key key);
@@ -297,7 +299,7 @@ object has been created:
     after the window has been closed.
 
   - Key combination to quit the application: `Ctrl-q` _(can be changed later)_
-    ```C++
+    ```cpp
     remotemo::Config& remotemo::Config::key_quit(); // Set to none
     remotemo::Config& remotemo::Config::key_quit(
             remotemo::Mod_keys modifier_keys, remotemo::F_key key);
@@ -315,7 +317,7 @@ object has been created:
     > **without** making sure all resources are cleaned up.
 
   - Closing window is the same as quitting: `false` _(can be changed later)_
-    ```C++
+    ```cpp
     remotemo::Config& remotemo::Config::closing_same_as_quit(
             bool is_closing_same_as_quit);
     ```
@@ -332,7 +334,7 @@ object has been created:
       the function-to-call-before-quitting.
   - Function to call before closing window: `[]() -> bool { return true; }`
     _(can be changed later)_
-    ```C++
+    ```cpp
     remotemo::Config& remotemo::Config::function_pre_close(
             const std::function<bool()>& func);
     ```
@@ -345,7 +347,7 @@ object has been created:
     > the default value instead.
   - Function to call before quitting: `[]() -> bool { return true; }`
     _(can be changed later)_
-    ```C++
+    ```cpp
     remotemo::Config& remotemo::Config::function_pre_quit(
             const std::function<bool()>& func);
     ```
@@ -364,7 +366,7 @@ object has been created:
   will be in charge of destroying it).
 
 - Background: `nullptr`
-  ```C++
+  ```cpp
   remotemo::Config& remotemo::Config::background(SDL_Texture* background);
   ```
 
@@ -374,7 +376,7 @@ object has been created:
     - Background file path: `"res/img/terminal_screen.png"` (which will be
       converted to `"res\\img\\terminal_screen.png"` on operating systems that
       have `\` as a path separator).
-      ```C++
+      ```cpp
       remotemo::Config& remotemo::Config::background_file_path(
               const std::string& file_path);
       ```
@@ -431,7 +433,7 @@ object has been created:
   - the area of the background where the text is to be drawn:
     `x: 188.25f, y: 149.25f, w: 560.0f, h: 432.0f`
 
-  ```C++
+  ```cpp
   remotemo::Config& remotemo::Config::background_min_area(int x, int y,
           int w, int h);
   remotemo::Config& remotemo::Config::background_min_area(SDL_Rect area);
@@ -443,7 +445,7 @@ object has been created:
   > zero.
 
 - Font-bitmap: `nullptr`
-  ```C++
+  ```cpp
   remotemo::Config& remotemo::Config::font_bitmap(SDL_Texture* font_bitmap);
   ```
   - If set to `nullptr` then the font-bitmap texture will be loaded from the
@@ -452,7 +454,7 @@ object has been created:
     - Font-bitmap file path: `"res/img/font_bitmap.png"` (which will be
       converted to `"res\\img\\font_bitmap.png"` on operating systems that
       have `\` as a path separator).
-      ```C++
+      ```cpp
       remotemo::Config& remotemo::Config::font_bitmap_file_path(
               const std::string& file_path);
       ```
@@ -487,9 +489,9 @@ object has been created:
     \
     This is the size, in pixels, of each character as they are drawn in the
     font-bitmap file.
-    ```C++
+    ```cpp
     remotemo::Config& remotemo::Config::font_size(int width, int height);
-    remotemo::Config& remotemo::Config::font_size(const SDL_Point& size);
+    remotemo::Config& remotemo::Config::font_size(const remotemo::Size& size);
     ```
 
 - The following are the default setting used to create a texture buffer where
@@ -507,9 +509,10 @@ object has been created:
     > **Note** This setting controls the color of **all** the text, both the
     > text that has already been printed to the screen and the text that is
     > going to be printed to the screen.
-  ```C++
+  ```cpp
   remotemo::Config& remotemo::Config::text_area_size(int columns, int lines);
-  remotemo::Config& remotemo::Config::text_area_size(const SDL_Point& size);
+  remotemo::Config& remotemo::Config::text_area_size(
+          const remotemo::Size& size);
   remotemo::Config& remotemo::Config::text_blend_mode(SDL_BlendMode mode);
   remotemo::Config& remotemo::Config::text_color(Uint8 red, Uint8 green,
           Uint8 blue);
@@ -574,9 +577,19 @@ before or while being called.
 
 ### Structs and enums
 
-```C++
+```cpp
 enum class remotemo::Wrapping {
   off, character, word
+};
+
+struct remotemo::Size {
+  int width;
+  int height;
+};
+
+struct remotemo::Point {
+  int x;
+  int y;
 };
 
 struct remotemo::Color {
@@ -621,9 +634,9 @@ update the window while running.
 > (depending on the scrolling settings) either all lines scroll up or the
 > output gets lost.
 
-```C++
+```cpp
 int remotemo::Remotemo::move_cursor(int x, int y);
-int remotemo::Remotemo::move_cursor(const SDL_Point& move);
+int remotemo::Remotemo::move_cursor(const remotemo::Size& move);
 ```
 
 Moves the cursor `x` columns to the right (negative `x` moves it to the left)
@@ -641,9 +654,9 @@ and `y` lines down (negative `y` moves it up).
   - `-6` (-4 + -2) if trying to go past left and bottom edges.
   - `-12` (-4 + -8) if trying to go past left and top edges.
 
-```C++
+```cpp
 int remotemo::Remotemo::set_cursor(int column, int line);
-int remotemo::Remotemo::set_cursor(const SDL_Point& position);
+int remotemo::Remotemo::set_cursor(const remotemo::Point& position);
 int remotemo::Remotemo::set_cursor_column(int column);
 int remotemo::Remotemo::set_cursor_line(int line);
 ```
@@ -654,14 +667,14 @@ Moves the cursor to the given position.
 - If trying to move the cursor past the edges of the text area, it stay where
   it was and the function will return `-1`.
 
-```C++
-SDL_Point remotemo::Remotemo::get_cursor_position();
+```cpp
+remotemo::Point remotemo::Remotemo::get_cursor_position();
 ```
 
 (Obviously) returns the current position of the cursor. As stated elsewhere,
 does not update the window.
 
-```C++
+```cpp
 int remotemo::Remotemo::pause(int pause_in_ms);
 ```
 
@@ -671,7 +684,7 @@ the window as needed, before returning:
 - `0` on success.
 - `-1` on error (e.g. the given time is negative).
 
-```C++
+```cpp
 void remotemo::Remotemo::clear(
   remotemo::Do_reset do_reset = remotemo::Do_reset::all);
 ```
@@ -685,7 +698,7 @@ Clears all the text area at once.
 No matter how 'inverse' is set, clearing the text area fills it all with the
 background color.
 
-```C++
+```cpp
 remotemo::Key remotemo::Remotemo::get_key();
 ```
 
@@ -693,7 +706,7 @@ Waits for a key being pressed and returns it (without displaying it on the
 screen). As noted regarding the enum class `remotemo::Key`, F-keys (e.g.
 `F1`), the keypad and modifier keys are not included.
 
-```C++
+```cpp
 std::string remotemo::Remotemo::get_input(int max_length);
 ```
 
@@ -719,7 +732,7 @@ also restrict the lenght of the text being entered on the screen.
 > **Note** No matter what keyboard layout the user has, this function will
 > behave as if it was an `US-ANSI` layout.
 
-```C++
+```cpp
 int remotemo::Remotemo::print(const std::string& text);
 ```
 
@@ -770,10 +783,10 @@ Then when trying to print any text to the hidden line, depending on the
   continuing printing the rest of the text.
 - If set to `false` then the rest of the string is lost.
 
-```C++
+```cpp
 int remotemo::Remotemo::print_at(int column, int line,
         const std::string& text);
-int remotemo::Remotemo::print_at(const SDL_Point& position,
+int remotemo::Remotemo::print_at(const remotemo::Point& position,
         const std::string& text);
 ```
 
@@ -785,9 +798,9 @@ Does the same thing as calling first `set_cursor()` and then `print()`.
 - Returns `-2` if some of the text could not get displayed (e.g. reached end
   of line while wrapping was set to `off`).
 
-```C++
+```cpp
 char remotemo::Remotemo::get_char_at(int column, int line);
-char remotemo::Remotemo::get_char_at(const SDL_Point& pos);
+char remotemo::Remotemo::get_char_at(const remotemo::Point& pos);
 ```
 
 - Returns the character that is at the given position (no matter if it was
@@ -795,9 +808,9 @@ char remotemo::Remotemo::get_char_at(const SDL_Point& pos);
   and then was moved up by scrolling).
 - If the given position is outside the text area, it returns `'\0'`.
 
-```C++
+```cpp
 bool remotemo::Remotemo::is_inverse_at(int column, int line);
-bool remotemo::Remotemo::is_inverse_at(const SDL_Point& pos);
+bool remotemo::Remotemo::is_inverse_at(const remotemo::Point& pos);
 ```
 - If the character at the given position was printed with the foreground and
   background colors inversed, it returns `true`.
@@ -808,7 +821,7 @@ bool remotemo::Remotemo::is_inverse_at(const SDL_Point& pos);
 <sup>[Back to top](#remotemo-api-design)</sup>
 ### Text output behaviour
 
-```C++
+```cpp
 bool remotemo::Remotemo::set_text_delay(int delay_in_ms);
 bool remotemo::Remotemo::set_text_speed(double char_per_second);
 int remotemo::Remotemo::get_text_delay();
@@ -829,7 +842,7 @@ Also note that when converting from `char per seconds` to `delay`, then some
 rounding might happen (e.g. any speed above 1000 char per second will probably
 be rounded down to a delay of 0 ms).
 
-```C++
+```cpp
 void remotemo::Remotemo::set_scrolling(bool scrolling);
 bool remotemo::Remotemo::get_scrolling();
 ```
@@ -837,7 +850,7 @@ bool remotemo::Remotemo::get_scrolling();
 Sets and gets the 'scrolling' property. See [Scrolling](#scrolling) above for
 more.
 
-```C++
+```cpp
 void remotemo::Remotemo::set_wrapping(remotemo::Wrapping wrapping);
 remotemo::Wrapping remotemo::Remotemo::get_wrapping();
 ```
@@ -845,7 +858,7 @@ remotemo::Wrapping remotemo::Remotemo::get_wrapping();
 Sets and gets the 'wrapping' property. See [Wrapping](#wrapping) above for
 more.
 
-```C++
+```cpp
 void remotemo::Remotemo::set_inverse(bool inverse);
 bool remotemo::Remotemo::get_inverse();
 ```
@@ -859,12 +872,12 @@ had already been printed to the screen.
 <sup>[Back to top](#remotemo-api-design)</sup>
 ### Text area settings
 
-```C++
+```cpp
 int remotemo::Remotemo::set_text_area_size(int columns, int lines);
-int remotemo::Remotemo::set_text_area_size(const SDL_Point& size);
+int remotemo::Remotemo::set_text_area_size(const remotemo::Size& size);
 int remotemo::Remotemo::get_text_area_columns();
 int remotemo::Remotemo::get_text_area_lines();
-SDL_Point remotemo::Remotemo::get_text_area_size();
+remotemo::Size remotemo::Remotemo::get_text_area_size();
 
 int remotemo::Remotemo::set_text_blend_mode(SDL_BlendMode mode);
 SDL_BlendMode remotemo::Remotemo::get_text_blend_mode();
@@ -877,15 +890,15 @@ remotemo::Color remotemo::Remotemo::get_text_color();
 <sup>[Back to top](#remotemo-api-design)</sup>
 ### Window settings
 
-```C++
+```cpp
 int remotemo::Remotemo::set_window_title(const std::string& title);
 std::string remotemo::Remotemo::get_window_title();
 int remotemo::Remotemo::set_window_size(int width, int height);
-int remotemo::Remotemo::set_window_size(const SDL_Point& size);
-SDL_Point remotemo::Remotemo::get_window_size();
+int remotemo::Remotemo::set_window_size(const remotemo::Size& size);
+remotemo::Size remotemo::Remotemo::get_window_size();
 int remotemo::Remotemo::set_window_position(int x, int y);
-int remotemo::Remotemo::set_window_position(const SDL_Point& position);
-SDL_Point remotemo::Remotemo::get_window_position();
+int remotemo::Remotemo::set_window_position(const remotemo::Point& position);
+remotemo::Point remotemo::Remotemo::get_window_position();
 int remotemo::Remotemo::set_window_resizable(bool is_resizable);
 bool remotemo::Remotemo::get_window_resizable();
 int remotemo::Remotemo::set_window_fullscreen(bool is_fullscreen);

--- a/docs/API_design.md
+++ b/docs/API_design.md
@@ -1,5 +1,5 @@
 # remoTemo API design
-_8th draft_
+_9th draft_
 
 > **Warning**
 >
@@ -436,10 +436,12 @@ object has been created:
   ```cpp
   remotemo::Config& remotemo::Config::background_min_area(int x, int y,
           int w, int h);
-  remotemo::Config& remotemo::Config::background_min_area(SDL_Rect area);
+  remotemo::Config& remotemo::Config::background_min_area(
+          remotemo::Rect<int> area);
   remotemo::Config& remotemo::Config::background_text_area(float x, float y,
           float width, float height);
-  remotemo::Config& remotemo::Config::background_text_area(SDL_FRect area);
+  remotemo::Config& remotemo::Config::background_text_area(
+          remotemo::Rect<float> area);
   ```
   > **Note** x and y are counted from the top-left corner, both starting at
   > zero.

--- a/include/remotemo/common_types.hpp
+++ b/include/remotemo/common_types.hpp
@@ -8,6 +8,16 @@ namespace remotemo {
 enum class Wrapping { off, character, word };
 enum class Do_reset { none, cursor, inverse, all };
 
+struct Size {
+  int width;
+  int height;
+};
+
+struct Point {
+  int x;
+  int y;
+};
+
 struct Color {
   Uint8 red {}, green {}, blue {};
 };

--- a/include/remotemo/common_types.hpp
+++ b/include/remotemo/common_types.hpp
@@ -18,8 +18,7 @@ struct Point {
   int y;
 };
 
-template<class T>
-struct Rect {
+template<class T> struct Rect {
   T x;
   T y;
   T width;

--- a/include/remotemo/common_types.hpp
+++ b/include/remotemo/common_types.hpp
@@ -18,6 +18,14 @@ struct Point {
   int y;
 };
 
+template<class T>
+struct Rect {
+  T x;
+  T y;
+  T width;
+  T height;
+};
+
 struct Color {
   Uint8 red {}, green {}, blue {};
 };

--- a/include/remotemo/config.hpp
+++ b/include/remotemo/config.hpp
@@ -20,8 +20,8 @@ struct Texture_config {
 };
 
 struct Backgr_config : Texture_config {
-  SDL_Rect min_area;
-  SDL_FRect text_area;
+  Rect<int> min_area;
+  Rect<float> text_area;
 };
 
 struct Font_config : Texture_config {
@@ -85,9 +85,9 @@ public:
   Config& background(SDL_Texture* background);
   Config& background_file_path(const std::string& file_path);
   Config& background_min_area(int x, int y, int w, int h);
-  Config& background_min_area(const SDL_Rect& area);
+  Config& background_min_area(const Rect<int>& area);
   Config& background_text_area(float x, float y, float w, float h);
-  Config& background_text_area(const SDL_FRect& area);
+  Config& background_text_area(const Rect<float>& area);
   [[nodiscard]] const Backgr_config& background() const
   {
     return m_background;
@@ -130,9 +130,9 @@ private:
   std::function<bool()> m_pre_quit_function {[]() -> bool { return true; }};
   Backgr_config m_background {{nullptr, "res/img/terminal_screen.png"s},
       // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-      SDL_Rect {118, 95, 700, 540},
+      Rect<int> {118, 95, 700, 540},
       // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-      SDL_FRect {188.25f, 149.25f, 560.0f, 432.0f}};
+      Rect<float> {188.25f, 149.25f, 560.0f, 432.0f}};
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   Font_config m_font {{nullptr, "res/img/font_bitmap.png"s}, 7, 18};
   Text_area_config m_text_area {

--- a/include/remotemo/config.hpp
+++ b/include/remotemo/config.hpp
@@ -59,9 +59,9 @@ public:
   Config& window(SDL_Window* window);
   Config& window_title(const std::string& title);
   Config& window_size(int width, int height);
-  Config& window_size(const SDL_Point& size);
+  Config& window_size(const Size& size);
   Config& window_position(int x, int y);
-  Config& window_position(const SDL_Point& pos);
+  Config& window_position(const Point& pos);
   Config& window_resizable(bool is_resizable);
   Config& window_fullscreen(bool is_fullscreen);
   [[nodiscard]] const Window_config& window() const { return m_window; }
@@ -96,11 +96,11 @@ public:
   Config& font_bitmap(SDL_Texture* font_bitmap);
   Config& font_bitmap_file_path(const std::string& file_path);
   Config& font_size(int width, int height);
-  Config& font_size(const SDL_Point& size);
+  Config& font_size(const Size& size);
   [[nodiscard]] const Font_config& font() const { return m_font; }
 
   Config& text_area_size(int columns, int lines);
-  Config& text_area_size(const SDL_Point& size);
+  Config& text_area_size(const Size& size);
   Config& text_blend_mode(SDL_BlendMode mode);
   Config& text_color(Uint8 red, Uint8 green, Uint8 blue);
   Config& text_color(const Color& color);

--- a/include/remotemo/remotemo.hpp
+++ b/include/remotemo/remotemo.hpp
@@ -9,8 +9,6 @@
 #include "remotemo/common_types.hpp"
 #include "remotemo/config.hpp"
 
-#include <SDL.h>
-
 namespace remotemo {
 class Engine;
 class Remotemo {
@@ -23,16 +21,16 @@ public:
   Remotemo(const Remotemo&) = delete;
   Remotemo& operator=(const Remotemo&) = delete;
 
-  int move_cursor(int x, int y) { return move_cursor(SDL_Point {x, y}); }
-  int move_cursor(const SDL_Point& move);
+  int move_cursor(int x, int y) { return move_cursor(Point {x, y}); }
+  int move_cursor(const Point& move);
   int set_cursor(int column, int line)
   {
-    return set_cursor(SDL_Point {column, line});
+    return set_cursor(Point {column, line});
   }
-  int set_cursor(const SDL_Point& position);
+  int set_cursor(const Point& position);
   int set_cursor_column(int column);
   int set_cursor_line(int line);
-  [[nodiscard]] SDL_Point get_cursor_position() const;
+  [[nodiscard]] Point get_cursor_position() const;
 
   int pause(int pause_in_ms);
   void clear(Do_reset do_reset = Do_reset::all);
@@ -42,18 +40,18 @@ public:
   int print(const std::string& text);
   int print_at(int column, int line, const std::string& text)
   {
-    return print_at(SDL_Point {column, line}, text);
+    return print_at(Point {column, line}, text);
   }
-  int print_at(const SDL_Point& position, const std::string& text);
-  [[nodiscard]] char get_char_at(const SDL_Point& pos) const;
+  int print_at(const Point& position, const std::string& text);
+  [[nodiscard]] char get_char_at(const Point& pos) const;
   [[nodiscard]] char get_char_at(int column, int line) const
   {
-    return get_char_at(SDL_Point {column, line});
+    return get_char_at(Point {column, line});
   }
-  [[nodiscard]] bool is_inverse_at(const SDL_Point& pos) const;
+  [[nodiscard]] bool is_inverse_at(const Point& pos) const;
   [[nodiscard]] bool is_inverse_at(int column, int line) const
   {
-    return is_inverse_at(SDL_Point {column, line});
+    return is_inverse_at(Point {column, line});
   }
   bool set_text_delay(int delay_in_ms);
   bool set_text_speed(double char_per_second);

--- a/include/remotemo/remotemo.hpp
+++ b/include/remotemo/remotemo.hpp
@@ -21,8 +21,11 @@ public:
   Remotemo(const Remotemo&) = delete;
   Remotemo& operator=(const Remotemo&) = delete;
 
-  int move_cursor(int x, int y) { return move_cursor(Point {x, y}); }
-  int move_cursor(const Point& move);
+  int move_cursor(int width, int height)
+  {
+    return move_cursor(Size {width, height});
+  }
+  int move_cursor(const Size& move);
   int set_cursor(int column, int line)
   {
     return set_cursor(Point {column, line});

--- a/src/background.hpp
+++ b/src/background.hpp
@@ -8,7 +8,6 @@
 #include "remotemo/config.hpp"
 #include "res_handler.hpp"
 #include "texture.hpp"
-#include <SDL.h>
 
 namespace remotemo {
 class Background : public Texture {
@@ -22,12 +21,12 @@ public:
 
   static std::optional<Background> create(const Backgr_config& backgr_config,
       Res_handler<SDL_Texture>&& backgr_texture, SDL_Renderer* renderer);
-  [[nodiscard]] const SDL_Rect& min_area() const { return m_min_area; }
-  [[nodiscard]] const SDL_FRect& text_area() const { return m_text_area; }
+  [[nodiscard]] const Rect<int>& min_area() const { return m_min_area; }
+  [[nodiscard]] const Rect<float>& text_area() const { return m_text_area; }
 
 private:
-  SDL_Rect m_min_area;
-  SDL_FRect m_text_area;
+  Rect<int> m_min_area;
+  Rect<float> m_text_area;
 };
 } // namespace remotemo
 #endif // REMOTEMO_SRC_BACKGROUND_HPP

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -23,9 +23,9 @@ Config& Config::window_size(int width, int height)
   m_window.height = height;
   return *this;
 }
-Config& Config::window_size(const SDL_Point& size)
+Config& Config::window_size(const Size& size)
 {
-  return window_size(size.x, size.y);
+  return window_size(size.width, size.height);
 }
 Config& Config::window_position(int x, int y)
 {
@@ -33,7 +33,7 @@ Config& Config::window_position(int x, int y)
   m_window.pos_y = y;
   return *this;
 }
-Config& Config::window_position(const SDL_Point& pos)
+Config& Config::window_position(const Point& pos)
 {
   return window_position(pos.x, pos.y);
 }
@@ -189,9 +189,9 @@ Config& Config::font_size(int width, int height)
   m_font.height = height;
   return *this;
 }
-Config& Config::font_size(const SDL_Point& size)
+Config& Config::font_size(const Size& size)
 {
-  return font_size(size.x, size.y);
+  return font_size(size.width, size.height);
 }
 
 Config& Config::text_area_size(int columns, int lines)
@@ -200,9 +200,9 @@ Config& Config::text_area_size(int columns, int lines)
   m_text_area.lines = lines;
   return *this;
 }
-Config& Config::text_area_size(const SDL_Point& size)
+Config& Config::text_area_size(const Size& size)
 {
-  return text_area_size(size.x, size.y);
+  return text_area_size(size.width, size.height);
 }
 Config& Config::text_blend_mode(SDL_BlendMode mode)
 {

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -156,18 +156,18 @@ Config& Config::background_file_path(const std::string& file_path)
 }
 Config& Config::background_min_area(int x, int y, int w, int h)
 {
-  return background_min_area(SDL_Rect {x, y, w, h});
+  return background_min_area(Rect<int> {x, y, w, h});
 }
-Config& Config::background_min_area(const SDL_Rect& area)
+Config& Config::background_min_area(const Rect<int>& area)
 {
   m_background.min_area = area;
   return *this;
 }
 Config& Config::background_text_area(float x, float y, float w, float h)
 {
-  return background_text_area(SDL_FRect {x, y, w, h});
+  return background_text_area(Rect<float> {x, y, w, h});
 }
-Config& Config::background_text_area(const SDL_FRect& area)
+Config& Config::background_text_area(const Rect<float>& area)
 {
   m_background.text_area = area;
   return *this;

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -91,8 +91,8 @@ Engine::Engine(Main_SDL_handler main_sdl_handler,
 void Engine::set_screen_display_settings()
 {
   auto backgr_texture_size = m_background->texture_size();
-  m_background_target.w = backgr_texture_size.x;
-  m_background_target.h = backgr_texture_size.y;
+  m_background_target.w = backgr_texture_size.width;
+  m_background_target.h = backgr_texture_size.height;
   auto backgr_text_area = m_background->text_area();
   m_text_target.w = backgr_text_area.w;
   m_text_target.h = backgr_text_area.h;
@@ -103,18 +103,20 @@ void Engine::refresh_screen_display_settings()
 {
   auto window_size = m_window->size();
   auto backgr_min_area = m_background->min_area();
-  float scale_w = static_cast<float>(window_size.x) /
+  float scale_w = static_cast<float>(window_size.width) /
                   static_cast<float>(backgr_min_area.w);
-  float scale_h = static_cast<float>(window_size.y) /
+  float scale_h = static_cast<float>(window_size.height) /
                   static_cast<float>(backgr_min_area.h);
   m_screen_scale = std::min(scale_w, scale_h);
   m_background_target.x =
-      ((static_cast<int>(static_cast<float>(window_size.x) / m_screen_scale) -
+      ((static_cast<int>(
+            static_cast<float>(window_size.width) / m_screen_scale) -
            backgr_min_area.w + 1) /
           2) -
       backgr_min_area.x;
   m_background_target.y =
-      ((static_cast<int>(static_cast<float>(window_size.y) / m_screen_scale) -
+      ((static_cast<int>(
+            static_cast<float>(window_size.height) / m_screen_scale) -
            backgr_min_area.h + 1) /
           2) -
       backgr_min_area.y;
@@ -184,25 +186,25 @@ std::unique_ptr<Engine> Engine::create(const Config& config)
 }
 
 
-SDL_Point Engine::cursor_pos() const
+Point Engine::cursor_pos() const
 {
   throw_if_window_closed();
   return m_text_display->cursor_pos();
 }
 
-SDL_Point Engine::text_area_size() const
+Size Engine::text_area_size() const
 {
   throw_if_window_closed();
-  return SDL_Point {m_text_display->columns(), m_text_display->lines()};
+  return Size {m_text_display->columns(), m_text_display->lines()};
 }
 
-char Engine::char_at(const SDL_Point& pos) const
+char Engine::char_at(const Point& pos) const
 {
   throw_if_window_closed();
   return m_text_display->char_at(pos);
 }
 
-bool Engine::is_inverse_at(const SDL_Point& pos) const
+bool Engine::is_inverse_at(const Point& pos) const
 {
   throw_if_window_closed();
   return m_text_display->is_inverse_at(pos);
@@ -277,7 +279,7 @@ void Engine::clear_screen()
   }
 }
 
-bool Engine::scroll_if_needed(SDL_Point* cursor_pos)
+bool Engine::scroll_if_needed(Point* cursor_pos)
 {
   if (!m_is_scrolling_allowed && cursor_pos->y >= m_text_display->lines()) {
     return false;
@@ -292,7 +294,7 @@ bool Engine::scroll_if_needed(SDL_Point* cursor_pos)
   return true;
 }
 
-void Engine::cursor_pos(const SDL_Point& pos)
+void Engine::cursor_pos(const Point& pos)
 {
   delay(m_delay_between_chars_ms);
   m_text_display->cursor_pos(pos);

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -94,8 +94,8 @@ void Engine::set_screen_display_settings()
   m_background_target.w = backgr_texture_size.width;
   m_background_target.h = backgr_texture_size.height;
   auto backgr_text_area = m_background->text_area();
-  m_text_target.w = backgr_text_area.w;
-  m_text_target.h = backgr_text_area.h;
+  m_text_target.w = backgr_text_area.width;
+  m_text_target.h = backgr_text_area.height;
   refresh_screen_display_settings();
 }
 
@@ -104,20 +104,20 @@ void Engine::refresh_screen_display_settings()
   auto window_size = m_window->size();
   auto backgr_min_area = m_background->min_area();
   float scale_w = static_cast<float>(window_size.width) /
-                  static_cast<float>(backgr_min_area.w);
+                  static_cast<float>(backgr_min_area.width);
   float scale_h = static_cast<float>(window_size.height) /
-                  static_cast<float>(backgr_min_area.h);
+                  static_cast<float>(backgr_min_area.height);
   m_screen_scale = std::min(scale_w, scale_h);
   m_background_target.x =
       ((static_cast<int>(
             static_cast<float>(window_size.width) / m_screen_scale) -
-           backgr_min_area.w + 1) /
+           backgr_min_area.width + 1) /
           2) -
       backgr_min_area.x;
   m_background_target.y =
       ((static_cast<int>(
             static_cast<float>(window_size.height) / m_screen_scale) -
-           backgr_min_area.h + 1) /
+           backgr_min_area.height + 1) /
           2) -
       backgr_min_area.y;
   auto backgr_text_area = m_background->text_area();

--- a/src/engine.hpp
+++ b/src/engine.hpp
@@ -69,12 +69,12 @@ public:
 
   static std::unique_ptr<Engine> create(const Config& config);
 
-  [[nodiscard]] SDL_Point cursor_pos() const;
-  [[nodiscard]] SDL_Point text_area_size() const;
-  [[nodiscard]] char char_at(const SDL_Point& pos) const;
-  [[nodiscard]] bool is_inverse_at(const SDL_Point& pos) const;
+  [[nodiscard]] Point cursor_pos() const;
+  [[nodiscard]] Size text_area_size() const;
+  [[nodiscard]] char char_at(const Point& pos) const;
+  [[nodiscard]] bool is_inverse_at(const Point& pos) const;
 
-  void cursor_pos(const SDL_Point& pos);
+  void cursor_pos(const Point& pos);
   bool display_string_at_cursor(
       const std::string& text, Wrapping text_wrapping);
 
@@ -106,7 +106,7 @@ protected:
   bool handle_standard_event(const SDL_Event& event);
   bool handle_window_event(const SDL_Event& event);
   void render_window();
-  bool scroll_if_needed(SDL_Point* cursor_pos);
+  bool scroll_if_needed(Point* cursor_pos);
   void set_screen_display_settings();
   void refresh_screen_display_settings();
   void throw_if_window_closed() const;

--- a/src/remotemo.cpp
+++ b/src/remotemo.cpp
@@ -68,12 +68,12 @@ bool version_is_pre_release()
 }
 
 
-int Remotemo::move_cursor(const Point& move)
+int Remotemo::move_cursor(const Size& move)
 {
   auto new_pos = m_engine->cursor_pos();
   auto area_size = m_engine->text_area_size();
   int return_code = 0;
-  new_pos.x += move.x;
+  new_pos.x += move.width;
   if (new_pos.x >= area_size.width) {
     new_pos.x = area_size.width - 1;
     return_code -= 1;
@@ -81,7 +81,7 @@ int Remotemo::move_cursor(const Point& move)
     new_pos.x = 0;
     return_code -= 4;
   }
-  new_pos.y += move.y;
+  new_pos.y += move.height;
   // NOTE Cursor is allowed to be one line below visible area:
   if (new_pos.y > area_size.height) {
     new_pos.y = area_size.height;

--- a/src/remotemo.cpp
+++ b/src/remotemo.cpp
@@ -68,14 +68,14 @@ bool version_is_pre_release()
 }
 
 
-int Remotemo::move_cursor(const SDL_Point& move)
+int Remotemo::move_cursor(const Point& move)
 {
   auto new_pos = m_engine->cursor_pos();
   auto area_size = m_engine->text_area_size();
   int return_code = 0;
   new_pos.x += move.x;
-  if (new_pos.x >= area_size.x) {
-    new_pos.x = area_size.x - 1;
+  if (new_pos.x >= area_size.width) {
+    new_pos.x = area_size.width - 1;
     return_code -= 1;
   } else if (new_pos.x < 0) {
     new_pos.x = 0;
@@ -83,8 +83,8 @@ int Remotemo::move_cursor(const SDL_Point& move)
   }
   new_pos.y += move.y;
   // NOTE Cursor is allowed to be one line below visible area:
-  if (new_pos.y > area_size.y) {
-    new_pos.y = area_size.y;
+  if (new_pos.y > area_size.height) {
+    new_pos.y = area_size.height;
     return_code -= 2;
   } else if (new_pos.y < 0) {
     new_pos.y = 0;
@@ -94,12 +94,12 @@ int Remotemo::move_cursor(const SDL_Point& move)
   return return_code;
 }
 
-int Remotemo::set_cursor(const SDL_Point& pos)
+int Remotemo::set_cursor(const Point& pos)
 {
   auto area_size = m_engine->text_area_size();
-  if (pos.x < 0 || pos.x >= area_size.x ||
+  if (pos.x < 0 || pos.x >= area_size.width ||
       // NOTE Cursor is allowed to be one line below visible area:
-      pos.y < 0 || pos.y > area_size.y) {
+      pos.y < 0 || pos.y > area_size.height) {
     m_engine->main_loop_once();
     return -1;
   }
@@ -121,7 +121,7 @@ int Remotemo::set_cursor_line(int line)
   return set_cursor(pos);
 }
 
-SDL_Point Remotemo::get_cursor_position() const
+Point Remotemo::get_cursor_position() const
 {
   return m_engine->cursor_pos();
 }
@@ -171,7 +171,7 @@ int Remotemo::print(const std::string& text)
   return 0;
 }
 
-int Remotemo::print_at(const SDL_Point& pos, const std::string& text)
+int Remotemo::print_at(const Point& pos, const std::string& text)
 {
   auto result = set_cursor(pos);
   if (result != 0) {
@@ -180,25 +180,25 @@ int Remotemo::print_at(const SDL_Point& pos, const std::string& text)
   return print(text);
 }
 
-char Remotemo::get_char_at(const SDL_Point& pos) const
+char Remotemo::get_char_at(const Point& pos) const
 {
   auto area_size = m_engine->text_area_size();
-  if (pos.x < 0 || pos.x >= area_size.x ||
+  if (pos.x < 0 || pos.x >= area_size.width ||
       // NOTE Although the cursor is allowed to be one line below the screen,
       // there is no content there.
-      pos.y < 0 || pos.y > area_size.y) {
+      pos.y < 0 || pos.y > area_size.height) {
     return 0;
   }
   return m_engine->char_at(pos);
 }
 
-bool Remotemo::is_inverse_at(const SDL_Point& pos) const
+bool Remotemo::is_inverse_at(const Point& pos) const
 {
   auto area_size = m_engine->text_area_size();
-  if (pos.x < 0 || pos.x >= area_size.x ||
+  if (pos.x < 0 || pos.x >= area_size.width ||
       // NOTE Although the cursor is allowed to be one line below the screen,
       // there is no content there.
-      pos.y < 0 || pos.y > area_size.y) {
+      pos.y < 0 || pos.y > area_size.height) {
     return false;
   }
   return m_engine->is_inverse_at(pos);

--- a/src/text_display.cpp
+++ b/src/text_display.cpp
@@ -8,11 +8,11 @@ std::optional<Text_display> Text_display::create(Font&& font,
   // That seems to be needed so that when stretching the content to the
   // screen, then the outer border of the content gets the same look as the
   // rest of the content:
-  SDL_Point area_size {(font.char_width() * text_area_config.columns) + 2,
+  Size area_size {(font.char_width() * text_area_config.columns) + 2,
       // + 1 line to make scrolling simpler:
       (font.char_height() * (text_area_config.lines + 1)) + 2};
   auto* texture = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGBA32,
-      SDL_TEXTUREACCESS_TARGET, area_size.x, area_size.y);
+      SDL_TEXTUREACCESS_TARGET, area_size.width, area_size.height);
   if (texture == nullptr) {
     ::SDL_LogCritical(SDL_LOG_CATEGORY_APPLICATION,
         "SDL_CreateTexture() failed: %s\n", ::SDL_GetError());
@@ -28,17 +28,17 @@ std::optional<Text_display> Text_display::create(Font&& font,
 }
 
 
-char Text_display::char_at(const SDL_Point& pos) const
+char Text_display::char_at(const Point& pos) const
 {
   return m_display_content[pos.y][pos.x].character;
 }
 
-bool Text_display::is_inverse_at(const SDL_Point& pos) const
+bool Text_display::is_inverse_at(const Point& pos) const
 {
   return m_display_content[pos.y][pos.x].is_inversed;
 }
 
-void Text_display::cursor_pos(const SDL_Point& pos)
+void Text_display::cursor_pos(const Point& pos)
 {
   if (m_cursor_pos.x != pos.x || m_cursor_pos.y != pos.y) {
     show_char_hidden_by_cursor();
@@ -95,10 +95,10 @@ void Text_display::clear_line(int line)
   SDL_SetTextureBlendMode(res(), SDL_BLENDMODE_NONE);
   SDL_SetTextureColorMod(res(), white.red, white.green, white.blue);
 
-  int line_length = texture_size().x - 2;
+  int line_length = texture_size().width - 2;
   int line_height = m_font.char_height();
   SDL_Rect area_to_be_copied = {
-      1, texture_size().y - line_height, line_length, line_height};
+      1, texture_size().height - line_height, line_length, line_height};
   SDL_Rect target_area = {
       1, 1 + (line * line_height), line_length, line_height};
   SDL_RenderCopy(m_renderer, res(), &area_to_be_copied, &target_area);
@@ -118,9 +118,9 @@ void Text_display::scroll_up_one_line()
   SDL_SetTextureBlendMode(res(), SDL_BLENDMODE_NONE);
   SDL_SetTextureColorMod(res(), white.red, white.green, white.blue);
 
-  int line_length = texture_size().x - 2;
+  int line_length = texture_size().width - 2;
   int line_height = m_font.char_height();
-  int scrolling_lines_height = texture_size().y - 2 - line_height;
+  int scrolling_lines_height = texture_size().height - 2 - line_height;
   SDL_Rect area_to_be_moved = {
       1, 1 + line_height, line_length, scrolling_lines_height};
   SDL_Rect target_area = {1, 1, line_length, scrolling_lines_height};
@@ -136,7 +136,7 @@ void Text_display::scroll_up_one_line()
 }
 
 void Text_display::display_char_at(
-    int character, bool is_output_inversed, const SDL_Point& pos)
+    int character, bool is_output_inversed, const Point& pos)
 {
   if (pos.x >= m_columns || pos.y >= m_lines) {
     return;

--- a/src/text_display.hpp
+++ b/src/text_display.hpp
@@ -34,10 +34,10 @@ public:
   [[nodiscard]] const Font& font() const { return m_font; }
   [[nodiscard]] int columns() const { return m_columns; }
   [[nodiscard]] int lines() const { return m_lines; }
-  [[nodiscard]] SDL_Point cursor_pos() const { return m_cursor_pos; }
-  [[nodiscard]] char char_at(const SDL_Point& pos) const;
-  [[nodiscard]] bool is_inverse_at(const SDL_Point& pos) const;
-  void cursor_pos(const SDL_Point& pos);
+  [[nodiscard]] Point cursor_pos() const { return m_cursor_pos; }
+  [[nodiscard]] char char_at(const Point& pos) const;
+  [[nodiscard]] bool is_inverse_at(const Point& pos) const;
+  void cursor_pos(const Point& pos);
   void update_cursor();
   void show_char_hidden_by_cursor();
   void is_output_inversed(bool inverse) { m_is_output_inversed = inverse; }
@@ -51,7 +51,7 @@ public:
 
 private:
   void display_char_at(
-      int character, bool is_output_inverse, const SDL_Point& pos);
+      int character, bool is_output_inverse, const Point& pos);
 
   SDL_Renderer* m_renderer;
   Font m_font;
@@ -61,7 +61,7 @@ private:
   Color m_text_to_screen_color;
   std::vector<Display_square> m_empty_line;
   std::deque<std::vector<Display_square>> m_display_content;
-  SDL_Point m_cursor_pos {0, 0};
+  Point m_cursor_pos {0, 0};
   bool m_is_cursor_visible {true};
   bool m_is_cursor_updated {false};
   bool m_is_output_inversed {false};

--- a/src/texture.cpp
+++ b/src/texture.cpp
@@ -35,8 +35,8 @@ bool Texture::load(SDL_Renderer* renderer, const std::string& file_path)
     return false;
   }
   is_owned(true);
-  if (::SDL_QueryTexture(res(), nullptr, nullptr, &m_texture_size.x,
-          &m_texture_size.y) != 0) {
+  if (::SDL_QueryTexture(res(), nullptr, nullptr, &m_texture_size.width,
+          &m_texture_size.height) != 0) {
     ::SDL_LogCritical(SDL_LOG_CATEGORY_APPLICATION,
         "Getting size of texture \"%s\" failed: %s\n", texture_path.c_str(),
         ::SDL_GetError());

--- a/src/texture.hpp
+++ b/src/texture.hpp
@@ -22,19 +22,16 @@ public:
   {}
 
   bool load(SDL_Renderer* renderer, const std::string& file_path);
-  [[nodiscard]] const SDL_Point& texture_size() const
-  {
-    return m_texture_size;
-  }
+  [[nodiscard]] const Size& texture_size() const { return m_texture_size; }
   static void reset_base_path() { m_base_path.reset(); }
   static bool set_base_path();
 
 protected:
-  void texture_size(const SDL_Point& size) { m_texture_size = size; }
+  void texture_size(const Size& size) { m_texture_size = size; }
 
 private:
   static std::optional<std::filesystem::path> m_base_path;
-  SDL_Point m_texture_size {0, 0};
+  Size m_texture_size {0, 0};
 };
 } // namespace remotemo
 #endif // REMOTEMO_SRC_TEXTURE_HPP

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -32,7 +32,7 @@ bool Window::setup(const Window_config& window_config)
 
 void Window::refresh_local_size()
 {
-  ::SDL_GetWindowSize(res(), &m_size.x, &m_size.y);
+  ::SDL_GetWindowSize(res(), &m_size.width, &m_size.height);
 }
 
 void Window::refresh_local_flags()

--- a/src/window.hpp
+++ b/src/window.hpp
@@ -21,13 +21,13 @@ public:
   void refresh_local_size();
   void refresh_local_flags();
   void set_fullscreen(bool do_make_fullscreen);
-  [[nodiscard]] const SDL_Point& size() const { return m_size; }
+  [[nodiscard]] const Size& size() const { return m_size; }
   [[nodiscard]] bool is_fullscreen() const { return m_is_fullscreen; }
 
 private:
   bool setup(const Window_config& window_config);
 
-  SDL_Point m_size {0, 0};
+  Size m_size {0, 0};
   bool m_is_fullscreen {false};
 };
 } // namespace remotemo

--- a/tests/src/test_init.hpp
+++ b/tests/src/test_init.hpp
@@ -8,6 +8,7 @@
 #include <optional>
 
 #include "mock_sdl.hpp"
+#include <remotemo/config.hpp>
 
 ///////////////////////////////////
 // Helper structures and objects:
@@ -72,8 +73,8 @@ extern const std::array<Conf_resources, 6> valid_conf_res;
 
 struct Win_conf {
   std::optional<std::string> title {};
-  std::optional<SDL_Point> size {};
-  std::optional<SDL_Point> pos {};
+  std::optional<remotemo::Size> size {};
+  std::optional<remotemo::Point> pos {};
   std::optional<bool> is_resizable {};
   std::optional<bool> is_fullscreen {};
 
@@ -83,8 +84,8 @@ struct Win_conf {
 struct Texture_conf {
   std::optional<std::string> backgr_file_path {};
   std::optional<std::string> font_bitmap_file_path {};
-  std::optional<SDL_Point> font_size {};
-  std::optional<SDL_Point> text_area_size {};
+  std::optional<remotemo::Size> font_size {};
+  std::optional<remotemo::Size> text_area_size {};
   std::optional<SDL_BlendMode> text_blend_mode {};
   std::optional<remotemo::Color> text_color {};
 

--- a/tests/src/test_init_helpers.cpp
+++ b/tests/src/test_init_helpers.cpp
@@ -335,7 +335,8 @@ std::string Win_conf::describe() const
     oss << "Title:           " << *title << "\n";
   }
   if (size.has_value()) {
-    oss << "Size:            (" << size->x << ", " << size->y << ")\n";
+    oss << "Size:            (" << size->width << ", " << size->height
+        << ")\n";
   }
   if (pos.has_value()) {
     oss << "Position:        (" << pos->x << ", " << pos->y << ")\n";
@@ -361,12 +362,12 @@ std::string Texture_conf::describe() const
     oss << "Font bitm. path: " << *font_bitmap_file_path << "\n";
   }
   if (font_size.has_value()) {
-    oss << "Font size:       (" << font_size->x << ", " << font_size->y
-        << ")\n";
+    oss << "Font size:       (" << font_size->width << ", "
+        << font_size->height << ")\n";
   }
   if (text_area_size.has_value()) {
-    oss << "Text area size:  (" << text_area_size->x << ", "
-        << text_area_size->y << ")\n";
+    oss << "Text area size:  (" << text_area_size->width << ", "
+        << text_area_size->height << ")\n";
   }
   if (text_blend_mode.has_value()) {
     oss << "Text blend mode: ";
@@ -433,19 +434,19 @@ void Init_status::attempt_create_window(
   std::string regex_title =
       "^"s + win_conf.title.value_or("Retro Monochrome Text Monitor") + "$";
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-  SDL_Point size = win_conf.size.value_or(SDL_Point {1280, 720});
-  SDL_Point pos = win_conf.pos.value_or(
-      SDL_Point {SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED});
+  remotemo::Size size = win_conf.size.value_or(remotemo::Size {1280, 720});
+  remotemo::Point pos = win_conf.pos.value_or(
+      remotemo::Point {SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED});
   Uint32 flags =
       (win_conf.is_resizable.value_or(true) ? SDL_WINDOW_RESIZABLE : 0) |
       (win_conf.is_fullscreen.value_or(false) ? SDL_WINDOW_FULLSCREEN_DESKTOP
                                               : 0);
   SDL_Window* create_win_ret = should_success ? d_new_win : nullptr;
-  exps.push_back(NAMED_REQUIRE_CALL(mock_SDL,
-      mock_CreateWindow(re(regex_title), pos.x, pos.y, size.x, size.y, flags))
-                     .RETURN(create_win_ret)
-                     .IN_SEQUENCE(
-                         seqs.main, seqs.font, seqs.backgr, seqs.t_area));
+  exps.push_back(
+      NAMED_REQUIRE_CALL(mock_SDL, mock_CreateWindow(re(regex_title), pos.x,
+                                       pos.y, size.width, size.height, flags))
+          .RETURN(create_win_ret)
+          .IN_SEQUENCE(seqs.main, seqs.font, seqs.backgr, seqs.t_area));
   ready_res.win = create_win_ret;
   to_be_cleaned_up.win = create_win_ret;
 }
@@ -506,13 +507,13 @@ void Init_status::attempt_setup_textures(
     }
   }
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-  auto font_size = texture_conf.font_size.value_or(SDL_Point {7, 18});
-  auto t_area_size = texture_conf.text_area_size.value_or(
-      SDL_Point {40, 24}); // NOLINT(cppcoreguidelines-avoid-magic-numbers)
+  auto font_size = texture_conf.font_size.value_or(remotemo::Size {7, 18});
+  auto t_area_size = texture_conf.text_area_size.value_or(remotemo::Size {
+      40, 24}); // NOLINT(cppcoreguidelines-avoid-magic-numbers)
   exps_t_area.setup = NAMED_REQUIRE_CALL(mock_SDL,
       mock_CreateTexture(ready_res.render, SDL_PIXELFORMAT_RGBA32,
-          SDL_TEXTUREACCESS_TARGET, (t_area_size.x * font_size.x) + 2,
-          ((t_area_size.y + 1) * font_size.y) + 2))
+          SDL_TEXTUREACCESS_TARGET, (t_area_size.width * font_size.width) + 2,
+          ((t_area_size.height + 1) * font_size.height) + 2))
                           .TIMES(0, 1)
                           .RETURN(exp_results.t_area)
                           .IN_SEQUENCE(seqs.main, seqs.t_area);

--- a/tests/src/test_io.cpp
+++ b/tests/src/test_io.cpp
@@ -37,7 +37,7 @@ std::string get_line_str(int line_num, const remotemo::Engine* engine)
 {
   std::stringstream line {};
   auto area_size = engine->text_area_size();
-  for (SDL_Point pos {0, line_num}; pos.x < area_size.x; pos.x++) {
+  for (remotemo::Point pos {0, line_num}; pos.x < area_size.width; pos.x++) {
     line << engine->char_at(pos);
   }
   return line.str();
@@ -59,7 +59,7 @@ std::deque<bool> get_line_is_inverse(
 {
   std::deque<bool> line {};
   auto area_size = engine->text_area_size();
-  for (SDL_Point pos {0, line_num}; pos.x < area_size.x; pos.x++) {
+  for (remotemo::Point pos {0, line_num}; pos.x < area_size.width; pos.x++) {
     line.push_back(engine->is_inverse_at(pos));
   }
   return line;
@@ -78,7 +78,8 @@ void compare_to_content(
 }
 
 void check_status(const Console_content& expected_content,
-    const SDL_Point& expected_cursor_pos, const remotemo::Engine* engine)
+    const remotemo::Point& expected_cursor_pos,
+    const remotemo::Engine* engine)
 {
   compare_to_content(expected_content.is_inv, engine);
   compare_to_content(expected_content.text, engine);
@@ -136,18 +137,18 @@ void delayed_key_press(int delay_ms, const Get_key_test_param& key)
 TEST_CASE("Cursor position can be controlled directly", "[cursor]")
 {
   struct Cursor_param {
-    SDL_Point param;
+    remotemo::Point param;
     int result;
-    SDL_Point pos;
+    remotemo::Point pos;
   };
 
-  const std::vector<SDL_Point> area_sizes {{
+  const std::vector<remotemo::Size> area_sizes {{
       {default_columns, default_lines}, // i.e. use default
       {20, 12},                         // default / 2
       {80, 36}                          //
   }};
   auto a_size = GENERATE_REF(from_range(area_sizes));
-  auto config = setup(a_size.x, a_size.y);
+  auto config = setup(a_size.width, a_size.height);
   auto t = remotemo::create(config);
   t->set_text_delay(0);
 
@@ -169,15 +170,15 @@ TEST_CASE("Cursor position can be controlled directly", "[cursor]")
     }};
 
     auto move = GENERATE_COPY(from_range(valid_moves));
-    if (move.param.x + 10 >= a_size.x) {
-      move.param.x = a_size.x - 11;
-      move.pos.x = a_size.x - 1;
+    if (move.param.x + 10 >= a_size.width) {
+      move.param.x = a_size.width - 11;
+      move.pos.x = a_size.width - 1;
     }
-    if (move.param.y + 10 > a_size.y) {
-      move.param.y = a_size.y - 10;
-      move.pos.y = a_size.y;
+    if (move.param.y + 10 > a_size.height) {
+      move.param.y = a_size.height - 10;
+      move.pos.y = a_size.height;
     }
-    INFO("Area size (" << a_size.x << ", " << a_size.y << ") "
+    INFO("Area size (" << a_size.width << ", " << a_size.height << ") "
                        << "Start pos (10, 10). Move (" << move.param.x << ", "
                        << move.param.y << ") Expected: (" << move.pos.x
                        << ", " << move.pos.y << ")\n");
@@ -192,7 +193,8 @@ TEST_CASE("Cursor position can be controlled directly", "[cursor]")
       REQUIRE(pos.y == move.pos.y);
     }
 
-    SECTION("move_cursor(SDL_Point&), with valid parameters, should work")
+    SECTION(
+        "move_cursor(remotemo::Point&), with valid parameters, should work")
     {
       t->set_cursor(10, 10);
 
@@ -206,18 +208,18 @@ TEST_CASE("Cursor position can be controlled directly", "[cursor]")
   SECTION("move_cursor(), with invalid parameters, should fail")
   {
     const std::vector<Cursor_param> invalid_moves {{
-        {{400, 5}, -1, {a_size.x - 1, 10}},       // right
-        {{6, 400}, -2, {16, a_size.y}},           // bottom
-        {{-13, 6}, -4, {0, 11}},                  // left
-        {{4, -17}, -8, {14, 0}},                  // top
-        {{90, 90}, -3, {a_size.x - 1, a_size.y}}, // bottom right
-        {{99, -14}, -9, {a_size.x - 1, 0}},       // top right
-        {{-15, 60}, -6, {0, a_size.y}},           // bottom left
-        {{-13, -12}, -12, {0, 0}}                 // top left
+        {{400, 5}, -1, {a_size.width - 1, 10}},            // right
+        {{6, 400}, -2, {16, a_size.height}},               // bottom
+        {{-13, 6}, -4, {0, 11}},                           // left
+        {{4, -17}, -8, {14, 0}},                           // top
+        {{90, 90}, -3, {a_size.width - 1, a_size.height}}, // bottom right
+        {{99, -14}, -9, {a_size.width - 1, 0}},            // top right
+        {{-15, 60}, -6, {0, a_size.height}},               // bottom left
+        {{-13, -12}, -12, {0, 0}}                          // top left
     }};
 
     auto move = GENERATE_REF(from_range(invalid_moves));
-    INFO("Area size (" << a_size.x << ", " << a_size.y << ") "
+    INFO("Area size (" << a_size.width << ", " << a_size.height << ") "
                        << "Start pos (10, 5). Move (" << move.param.x << ", "
                        << move.param.y << ") Expected: (" << move.pos.x
                        << ", " << move.pos.y << ")\n");
@@ -231,7 +233,8 @@ TEST_CASE("Cursor position can be controlled directly", "[cursor]")
       REQUIRE(pos.x == move.pos.x);
       REQUIRE(pos.y == move.pos.y);
     }
-    SECTION("move_cursor(SDL_Point&), with invalid parameters, should fail")
+    SECTION(
+        "move_cursor(remotemo::Point&), with invalid parameters, should fail")
     {
       t->set_cursor(10, 5);
 
@@ -245,14 +248,14 @@ TEST_CASE("Cursor position can be controlled directly", "[cursor]")
   SECTION("set_cursor(), with valid parameters, should work")
   {
     const std::vector<Cursor_param> positions {{
-        {{4, 8}, 0, {4, 8}},                       //
-        {{2, 6}, 0, {2, 6}},                       //
-        {{a_size.x - 1, 5}, 0, {a_size.x - 1, 5}}, //
-        {{2, a_size.y}, 0, {2, a_size.y}}          //
+        {{4, 8}, 0, {4, 8}},                               //
+        {{2, 6}, 0, {2, 6}},                               //
+        {{a_size.width - 1, 5}, 0, {a_size.width - 1, 5}}, //
+        {{2, a_size.height}, 0, {2, a_size.height}}        //
     }};
 
     auto p = GENERATE_REF(from_range(positions));
-    INFO("Area size (" << a_size.x << ", " << a_size.y << ") "
+    INFO("Area size (" << a_size.width << ", " << a_size.height << ") "
                        << "Set (" << p.param.x << ", " << p.param.y
                        << ") Expected: (" << p.pos.x << ", " << p.pos.y
                        << ")\n");
@@ -264,7 +267,8 @@ TEST_CASE("Cursor position can be controlled directly", "[cursor]")
       REQUIRE(pos.x == p.pos.x);
       REQUIRE(pos.y == p.pos.y);
     }
-    SECTION("set_cursor(SDL_Point&), with valid parameters, should work")
+    SECTION(
+        "set_cursor(remotemo::Point&), with valid parameters, should work")
     {
       REQUIRE(t->set_cursor(p.param) == p.result);
       auto pos = t->get_cursor_position();
@@ -275,17 +279,17 @@ TEST_CASE("Cursor position can be controlled directly", "[cursor]")
   SECTION("set_cursor(), with invalid parameters, should fail")
   {
     const std::vector<Cursor_param> positions {{
-        {{-4, 8}, -1, {15, 10}},            //
-        {{8, -7}, -1, {15, 10}},            //
-        {{a_size.x, 10}, -1, {15, 10}},     //
-        {{15, a_size.y + 1}, -1, {15, 10}}, //
-        {{a_size.x + 5, 10}, -1, {15, 10}}, //
-        {{15, a_size.y + 5}, -1, {15, 10}}, //
+        {{-4, 8}, -1, {15, 10}},                 //
+        {{8, -7}, -1, {15, 10}},                 //
+        {{a_size.width, 10}, -1, {15, 10}},      //
+        {{15, a_size.height + 1}, -1, {15, 10}}, //
+        {{a_size.width + 5, 10}, -1, {15, 10}},  //
+        {{15, a_size.height + 5}, -1, {15, 10}}, //
     }};
     t->set_cursor(15, 10);
 
     auto p = GENERATE_REF(from_range(positions));
-    INFO("Area size (" << a_size.x << ", " << a_size.y << ") "
+    INFO("Area size (" << a_size.width << ", " << a_size.height << ") "
                        << "Set (" << p.param.x << ", " << p.param.y
                        << ") Expected: (" << p.pos.x << ", " << p.pos.y
                        << ")\n");
@@ -297,7 +301,8 @@ TEST_CASE("Cursor position can be controlled directly", "[cursor]")
       REQUIRE(pos.x == p.pos.x);
       REQUIRE(pos.y == p.pos.y);
     }
-    SECTION("set_cursor(SDL_Point&), with invalid parameters, should fail")
+    SECTION(
+        "set_cursor(remotemo::Point&), with invalid parameters, should fail")
     {
       REQUIRE(t->set_cursor(p.param) == p.result);
       auto pos = t->get_cursor_position();
@@ -309,14 +314,14 @@ TEST_CASE("Cursor position can be controlled directly", "[cursor]")
   SECTION("set_cursor_column(int), with a valid parameter, should work")
   {
     const std::vector<Cursor_param> positions {{
-        {{4, 0}, 0, {4, 5}},                       //
-        {{0, 0}, 0, {0, 5}},                       //
-        {{a_size.x - 7, 0}, 0, {a_size.x - 7, 5}}, //
-        {{a_size.x - 1, 0}, 0, {a_size.x - 1, 5}}  //
+        {{4, 0}, 0, {4, 5}},                               //
+        {{0, 0}, 0, {0, 5}},                               //
+        {{a_size.width - 7, 0}, 0, {a_size.width - 7, 5}}, //
+        {{a_size.width - 1, 0}, 0, {a_size.width - 1, 5}}  //
     }};
     for (auto p : positions) {
       t->set_cursor(5, 5);
-      INFO("Area size (" << a_size.x << ", " << a_size.y << ") "
+      INFO("Area size (" << a_size.width << ", " << a_size.height << ") "
                          << "Set column (" << p.param.x << ") Expected: ("
                          << p.pos.x << ", " << p.pos.y << ")\n");
 
@@ -330,13 +335,13 @@ TEST_CASE("Cursor position can be controlled directly", "[cursor]")
   SECTION("set_cursor_column(int), with invalid parameters, should fail")
   {
     const std::vector<Cursor_param> positions {{
-        {{-4, 0}, -1, {10, 10}},           //
-        {{a_size.x, 0}, -1, {10, 10}},     //
-        {{a_size.x + 4, 0}, -1, {10, 10}}, //
+        {{-4, 0}, -1, {10, 10}},               //
+        {{a_size.width, 0}, -1, {10, 10}},     //
+        {{a_size.width + 4, 0}, -1, {10, 10}}, //
     }};
     for (auto p : positions) {
       t->set_cursor(10, 10);
-      INFO("Area size (" << a_size.x << ", " << a_size.y << ") "
+      INFO("Area size (" << a_size.width << ", " << a_size.height << ") "
                          << "Set column (" << p.param.x << ") Expected: ("
                          << p.pos.x << ", " << p.pos.y << ")\n");
 
@@ -350,14 +355,14 @@ TEST_CASE("Cursor position can be controlled directly", "[cursor]")
   SECTION("set_cursor_line(int), with a valid parameter, should work")
   {
     const std::vector<Cursor_param> positions {{
-        {{0, 0}, 0, {5, 0}},              //
-        {{0, 6}, 0, {5, 6}},              //
-        {{0, 5}, 0, {5, 5}},              //
-        {{0, a_size.y}, 0, {5, a_size.y}} //
+        {{0, 0}, 0, {5, 0}},                        //
+        {{0, 6}, 0, {5, 6}},                        //
+        {{0, 5}, 0, {5, 5}},                        //
+        {{0, a_size.height}, 0, {5, a_size.height}} //
     }};
     for (auto p : positions) {
       t->set_cursor(5, 5);
-      INFO("Area size (" << a_size.x << ", " << a_size.y << ") "
+      INFO("Area size (" << a_size.width << ", " << a_size.height << ") "
                          << "Set line (" << p.param.y << ") Expected: ("
                          << p.pos.x << ", " << p.pos.y << ")\n");
 
@@ -371,14 +376,14 @@ TEST_CASE("Cursor position can be controlled directly", "[cursor]")
   SECTION("set_cursor_line(int), with invalid parameters, should fail")
   {
     const std::vector<Cursor_param> positions {{
-        {{0, -8}, -1, {5, 10}},           //
-        {{0, a_size.y + 1}, -1, {5, 10}}, //
-        {{0, 50}, -1, {5, 10}},           //
+        {{0, -8}, -1, {5, 10}},                //
+        {{0, a_size.height + 1}, -1, {5, 10}}, //
+        {{0, 50}, -1, {5, 10}},                //
     }};
 
     for (auto p : positions) {
       t->set_cursor(5, 10);
-      INFO("Area size (" << a_size.x << ", " << a_size.y << ") "
+      INFO("Area size (" << a_size.width << ", " << a_size.height << ") "
                          << "Set line (" << p.param.y << ") Expected: ("
                          << p.pos.x << ", " << p.pos.y << ")\n");
 
@@ -431,7 +436,7 @@ TEST_CASE("print() and print_at() functions", "[print]")
   remotemo::Remotemo t {std::move(eng), config};
   t.set_text_delay(0);
   Console_content expected_content {lines, empty_line, normal_line};
-  SDL_Point expected_cursor_pos {0, 0};
+  remotemo::Point expected_cursor_pos {0, 0};
 
   SECTION("Checking starting status")
   {
@@ -542,7 +547,7 @@ TEST_CASE("print() - scroll set to true", "[print][scroll]")
   t.set_text_delay(0);
   REQUIRE(t.get_scrolling() == true);
   Console_content expected_content {lines, empty_line, normal_line};
-  SDL_Point expected_cursor_pos {0, 0};
+  remotemo::Point expected_cursor_pos {0, 0};
 
   SECTION("Printing text from starting position")
   {
@@ -573,7 +578,7 @@ TEST_CASE("print() - scroll set to true", "[print][scroll]")
 
   SECTION("print_at() w/ content one line below bottom should scroll up")
   {
-    const SDL_Point print_to_pos {2, lines};
+    const remotemo::Point print_to_pos {2, lines};
 
     for (const auto& text : {"Start scrolling"s, "no lines empty"s, "---"s,
              " "s, "New bottom line"s}) {
@@ -611,7 +616,7 @@ TEST_CASE("print() - wrap set to character", "[print][wrap]")
   t.set_text_delay(0);
   REQUIRE(t.get_wrapping() == remotemo::Wrapping::character);
   Console_content expected_content {lines, empty_line, normal_line};
-  SDL_Point expected_cursor_pos {0, 0};
+  remotemo::Point expected_cursor_pos {0, 0};
 
   SECTION("Printing text from starting position")
   {
@@ -675,7 +680,7 @@ TEST_CASE("print() - scroll is on and wrap set to character",
   t.set_text_delay(0);
   REQUIRE(t.get_wrapping() == remotemo::Wrapping::character);
   Console_content expected_content {lines, empty_line, normal_line};
-  SDL_Point expected_cursor_pos {0, 0};
+  remotemo::Point expected_cursor_pos {0, 0};
 
   SECTION("Printing text from starting position")
   {
@@ -739,7 +744,7 @@ TEST_CASE("The 'inverse' setting should affect printing", "[print][inverse]")
   remotemo::Remotemo t {std::move(eng), config};
   t.set_text_delay(0);
   Console_content expected_content {lines, empty_line, normal_line};
-  SDL_Point expected_cursor_pos {0, 0};
+  remotemo::Point expected_cursor_pos {0, 0};
 
   SECTION("Just calling set_inverse() should not change screen content")
   {
@@ -842,7 +847,7 @@ TEST_CASE("Inversed content should scroll the same way as the text",
   remotemo::Remotemo t {std::move(eng), config};
   t.set_text_delay(0);
   Console_content expected_content {lines, empty_line, normal_line};
-  SDL_Point expected_cursor_pos {0, 0};
+  remotemo::Point expected_cursor_pos {0, 0};
 
   t.set_inverse(true);
 


### PR DESCRIPTION
- [x] Use `remotemo::Point` and `remotemo::Size` instead of `SDL_Point` in public API
- [x] Use `remotemo::Rect` instead of `SDL_Rect` and `SDL_FRect` in public API
- [x] Document changes