### PR TITLE
Various cleanups

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(remotemo
     VERSION 0.1.0
     LANGUAGES CXX
 )
-set(remotemo_PRE_RELEASE_LABEL beta.2)
+set(remotemo_PRE_RELEASE_LABEL beta.3)
 
 if(NOT remotemo_PRE_RELEASE_LABEL STREQUAL "")
     set(remotemo_VERSION

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(remotemo
     VERSION 0.1.0
     LANGUAGES CXX
 )
-set(remotemo_PRE_RELEASE_LABEL beta.3)
+set(remotemo_PRE_RELEASE_LABEL beta.4)
 
 if(NOT remotemo_PRE_RELEASE_LABEL STREQUAL "")
     set(remotemo_VERSION

--- a/docs/API_design.md
+++ b/docs/API_design.md
@@ -1,5 +1,5 @@
 # remoTemo API design
-_9th draft_
+_11th draft_
 
 > **Warning**
 >
@@ -43,36 +43,51 @@ In short:
 - The `Major.Minor.Patch`-part of pre-release versions denotes the release
   version that will be released, not the one that is built on.
 
-The library provides a few functions that returns its name and its version:
+The library provides a struct and a few functions to provide you with its name
+and its version:
 
 ```cpp
+struct remotemo::Version {
+  int major;
+  int minor;
+  int patch;
+  std::string pre_release_label;
+  std::string full;
+};
+
 std::string remotemo::full_name();
-std::string remotemo::version_full();
-int remotemo::version_major();
-int remotemo::version_minor();
-int remotemo::version_patch();
-std::string remotemo::version_pre_release_label();
+remotemo::Version remotemo::version();
 bool remotemo::version_is_pre_release();
 ```
 
 Assuming the version to be `1.0.3`, they would return the following:
 
 - `remotemo::full_name()` will return the string `"remoTemo v1.0.3"`.
-- `remotemo::version_full()` will return the string `"1.0.3"`.
-- `remotemo::version_major()` will return the int `1`.
-- `remotemo::version_minor()` will return the int `0`.
-- `remotemo::version_patch()` will return the int `3`.
-- `remotemo::version_pre_release_label()` will return the string `""`.
+- `remotemo::version()` will return a `remotemo::Version` struct containing:
+  ```cpp
+  {
+    major = 1,
+    minor = 0,
+    patch = 3,
+    pre_release_label = "",
+    full = "1.0.3"
+  }
+  ```
 - `remotemo::version_is_pre_release()` will return the bool `false`.
 
 Assuming the version to be `1.1.0-beta.2`, they would return the following:
 
 - `remotemo::full_name()` will return the string `"remoTemo v1.1.0-beta.2"`.
-- `remotemo::version_full()` will return the string `"1.1.0-beta.2"`.
-- `remotemo::version_major()` will return the int `1`.
-- `remotemo::version_minor()` will return the int `1`.
-- `remotemo::version_patch()` will return the int `0`.
-- `remotemo::version_pre_release_label()` will return the string `"beta.2"`.
+- `remotemo::version()` will return a `remotemo::Version` struct containing:
+  ```cpp
+  {
+    major = 1,
+    minor = 1,
+    patch = 0,
+    pre_release_label = "beta.2",
+    full = "1.1.0-beta.2"
+  }
+  ```
 - `remotemo::version_is_pre_release()` will return the bool `true`.
 
 <sup>[Back to top](#remotemo-api-design)</sup>

--- a/docs/API_design.md
+++ b/docs/API_design.md
@@ -584,6 +584,13 @@ enum class remotemo::Wrapping {
   off, character, word
 };
 
+enum class Move_cursor_error {
+  past_right_edge = -1,
+  past_bottom_edge = -2,
+  past_left_edge = -4,
+  past_top_edge = -8
+};
+
 struct remotemo::Size {
   int width;
   int height;

--- a/include/remotemo/common_types.hpp
+++ b/include/remotemo/common_types.hpp
@@ -7,6 +7,12 @@ namespace remotemo {
 
 enum class Wrapping { off, character, word };
 enum class Do_reset { none, cursor, inverse, all };
+enum class Move_cursor_error {
+  past_right_edge = -1,
+  past_bottom_edge = -2,
+  past_left_edge = -4,
+  past_top_edge = -8
+};
 
 struct Size {
   int width;

--- a/include/remotemo/common_types.hpp
+++ b/include/remotemo/common_types.hpp
@@ -1,9 +1,18 @@
 #ifndef REMOTEMO_COMMON_TYPES_HPP
 #define REMOTEMO_COMMON_TYPES_HPP
 
+#include <string>
 #include <SDL.h>
 
 namespace remotemo {
+
+struct Version {
+  int major;
+  int minor;
+  int patch;
+  std::string pre_release_label;
+  std::string full;
+};
 
 enum class Wrapping { off, character, word };
 enum class Do_reset { none, cursor, inverse, all };

--- a/include/remotemo/remotemo.hpp
+++ b/include/remotemo/remotemo.hpp
@@ -81,11 +81,7 @@ std::optional<Remotemo> create();
 std::optional<Remotemo> create(const Config& config);
 
 std::string full_name();
-std::string version_full();
-int version_major();
-int version_minor();
-int version_patch();
-std::string version_pre_release_label();
+Version version();
 bool version_is_pre_release();
 } // namespace remotemo
 #endif // REMOTEMO_REMOTEMO_HPP

--- a/include/remotemo/remotemo.hpp
+++ b/include/remotemo/remotemo.hpp
@@ -12,8 +12,12 @@
 namespace remotemo {
 class Engine;
 class Remotemo {
+  friend std::optional<Remotemo> create(const Config& config);
+  // To allow unit tests to access private ctor:
+  friend Remotemo create_remotemo(
+      std::unique_ptr<Engine> engine, const Config& config);
+
 public:
-  Remotemo(std::unique_ptr<Engine> engine, const Config& config) noexcept;
   ~Remotemo() noexcept;
   Remotemo(Remotemo&& other) noexcept;
   Remotemo& operator=(Remotemo&& other) noexcept;
@@ -68,6 +72,7 @@ public:
   [[nodiscard]] bool get_inverse() const;
 
 private:
+  Remotemo(std::unique_ptr<Engine> engine, const Config& config) noexcept;
   std::unique_ptr<Engine> m_engine {};
   Wrapping m_text_wrapping {Wrapping::character};
 };

--- a/samples/wrap_n_scroll_test.cpp
+++ b/samples/wrap_n_scroll_test.cpp
@@ -52,11 +52,11 @@ void run_test(remotemo::Remotemo* text_monitor)
 int main([[maybe_unused]] int argc, [[maybe_unused]] char* argv[])
 {
   std::cout << "Name: " << remotemo::full_name() << '\n';
-  std::cout << "Version: " << remotemo::version_full() << '\n';
-  std::cout << "Major: " << remotemo::version_major() << '\n';
-  std::cout << "Minor: " << remotemo::version_minor() << '\n';
-  std::cout << "Patch: " << remotemo::version_patch() << '\n';
-  std::cout << "Pre-release label: " << remotemo::version_pre_release_label()
+  std::cout << "Version: " << remotemo::version().full << '\n';
+  std::cout << "Major: " << remotemo::version().major << '\n';
+  std::cout << "Minor: " << remotemo::version().minor << '\n';
+  std::cout << "Patch: " << remotemo::version().patch << '\n';
+  std::cout << "Pre-release label: " << remotemo::version().pre_release_label
             << '\n';
   std::cout << "Is pre-release? " << std::boolalpha
             << remotemo::version_is_pre_release() << std::noboolalpha << '\n';

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -1,6 +1,7 @@
 #include "engine.hpp"
 
 #include <algorithm>
+#include <vector>
 
 #include "font.hpp"
 #include "keyboard.hpp"
@@ -60,13 +61,11 @@ bool Key_combo_handler::is_in_event(const SDL_Event& event) const
     return false;
   }
   auto required_mod_keys = m_key_combo->modifier_keys();
-  for (auto mod_key : {KMOD_SHIFT, KMOD_CTRL, KMOD_ALT}) {
-    if (((required_mod_keys & mod_key) == 0) !=
-        ((event.key.keysym.mod & mod_key) == 0)) {
-      return false;
-    }
-  }
-  return true;
+  const std::vector<int> mod_keys = {KMOD_SHIFT, KMOD_CTRL, KMOD_ALT};
+  return std::all_of(mod_keys.cbegin(), mod_keys.cend(), [&](int mod_key) {
+    return (((required_mod_keys & mod_key) == 0) ==
+            ((event.key.keysym.mod & mod_key) == 0));
+  });
 }
 
 

--- a/src/engine.hpp
+++ b/src/engine.hpp
@@ -46,7 +46,7 @@ public:
       const std::optional<Key_combo>& combo) noexcept
       : m_key_combo(combo)
   {}
-  bool is_in_event(const SDL_Event& event) const;
+  [[nodiscard]] bool is_in_event(const SDL_Event& event) const;
 
 private:
   std::optional<Key_combo> m_key_combo {};

--- a/src/remotemo.cpp
+++ b/src/remotemo.cpp
@@ -33,38 +33,18 @@ std::optional<Remotemo> create(const Config& config)
 std::string full_name()
 {
   std::stringstream full_n;
-  full_n << "remoTemo v" << version::full;
+  full_n << "remoTemo v" << version_.full;
   return full_n.str();
 }
 
-std::string version_full()
+Version version()
 {
-  return static_cast<std::string>(version::full);
-}
-
-int version_major()
-{
-  return version::major;
-}
-
-int version_minor()
-{
-  return version::minor;
-}
-
-int version_patch()
-{
-  return version::patch;
-}
-
-std::string version_pre_release_label()
-{
-  return static_cast<std::string>(version::pre_release_label);
+  return version_;
 }
 
 bool version_is_pre_release()
 {
-  return (*version::pre_release_label != '\0');
+  return !version_.pre_release_label.empty();
 }
 
 

--- a/src/remotemo.cpp
+++ b/src/remotemo.cpp
@@ -76,19 +76,19 @@ int Remotemo::move_cursor(const Size& move)
   new_pos.x += move.width;
   if (new_pos.x >= area_size.width) {
     new_pos.x = area_size.width - 1;
-    return_code -= 1;
+    return_code += static_cast<int>(Move_cursor_error::past_right_edge);
   } else if (new_pos.x < 0) {
     new_pos.x = 0;
-    return_code -= 4;
+    return_code += static_cast<int>(Move_cursor_error::past_left_edge);
   }
   new_pos.y += move.height;
   // NOTE Cursor is allowed to be one line below visible area:
   if (new_pos.y > area_size.height) {
     new_pos.y = area_size.height;
-    return_code -= 2;
+    return_code += static_cast<int>(Move_cursor_error::past_bottom_edge);
   } else if (new_pos.y < 0) {
     new_pos.y = 0;
-    return_code -= 8;
+    return_code += static_cast<int>(Move_cursor_error::past_top_edge);
   }
   m_engine->cursor_pos(new_pos);
   return return_code;

--- a/src/texture.cpp
+++ b/src/texture.cpp
@@ -3,6 +3,10 @@
 #include <SDL_image.h>
 
 namespace remotemo {
+// This is a private static member variable. That makes it **NOT** globally
+// accessible but clang-tidy has a bug that makes it report it anyway
+// See https://github.com/llvm/llvm-project/issues/47384
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 std::optional<std::filesystem::path> Texture::m_base_path {};
 
 bool Texture::set_base_path()

--- a/src/texture.hpp
+++ b/src/texture.hpp
@@ -30,6 +30,10 @@ protected:
   void texture_size(const Size& size) { m_texture_size = size; }
 
 private:
+  // This is a private static member variable. That makes it **NOT** globally
+  // accessible but clang-tidy has a bug that makes it report it anyway
+  // See https://github.com/llvm/llvm-project/issues/47384
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   static std::optional<std::filesystem::path> m_base_path;
   Size m_texture_size {0, 0};
 };

--- a/src/version.hpp.in
+++ b/src/version.hpp.in
@@ -1,13 +1,15 @@
 #ifndef REMOTEMO_SRC_VERSION_HPP
 #define REMOTEMO_SRC_VERSION_HPP
 
+#include <remotemo/common_types.hpp>
+
 namespace remotemo {
-namespace version {
-constexpr int major = @remotemo_VERSION_MAJOR@;
-constexpr int minor = @remotemo_VERSION_MINOR@;
-constexpr int patch = @remotemo_VERSION_PATCH@;
-const char* const full = "@remotemo_VERSION@";
-const char* const pre_release_label = "@remotemo_PRE_RELEASE_LABEL@";
-} // namespace version
+const Version version_ {
+  @remotemo_VERSION_MAJOR@,
+  @remotemo_VERSION_MINOR@,
+  @remotemo_VERSION_PATCH@,
+  "@remotemo_PRE_RELEASE_LABEL@",
+  "@remotemo_VERSION@"
+};
 } // namespace remotemo
 #endif // REMOTEMO_SRC_VERSION_HPP

--- a/tests/.clang-tidy
+++ b/tests/.clang-tidy
@@ -1,6 +1,6 @@
 ---
 Checks:
-'clang-diagnostic-*,clang-analyzer-*,bugprone-*,cert-*,cppcoreguidelines-*,-cppcoreguidelines-pro-type-vararg,-cppcoreguidelines-pro-type-reinterpret-cast,google-*,-google-objc-*,-google-readability-*,-google-upgrade-googletest-case,hicpp-exception-baseclass,hicpp-multiway-paths-covered,hicpp-no-assembler,llvm-*,-llvm-include-order,misc-*,modernize-*,-modernize-use-trailing-return-type,-modernize-avoid-c-arrays,performance-*,readability-*,-readability-magic-numbers'
+'clang-diagnostic-*,clang-analyzer-*,bugprone-*,cert-*,cppcoreguidelines-*,-cppcoreguidelines-pro-type-vararg,-cppcoreguidelines-pro-type-reinterpret-cast,google-*,-google-objc-*,-google-readability-*,-google-upgrade-googletest-case,hicpp-exception-baseclass,hicpp-multiway-paths-covered,hicpp-no-assembler,llvm-*,-llvm-include-order,misc-*,-misc-non-private-member-*,modernize-*,-modernize-use-trailing-return-type,performance-*,readability-*,-*-magic-numbers,-readability-function-cognitive-complexity,-*-avoid-c-arrays,-*-const-cast,-*-non-const-global-*'
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
 AnalyzeTemporaryDtors: false

--- a/tests/src/test_init.hpp
+++ b/tests/src/test_init.hpp
@@ -66,8 +66,8 @@ struct Conf_resources {
   void expected_cleanup(std::list<tr_exp>* exps, Test_seqs* seqs) const;
   void check_win_has_renderer(std::list<tr_exp>* exps, Test_seqs* seqs) const;
   void all_checks_succeeds(std::list<tr_exp>* exps, Test_seqs* seqs) const;
-  std::string list_textures() const;
-  std::string describe() const;
+  [[nodiscard]] std::string list_textures() const;
+  [[nodiscard]] std::string describe() const;
 };
 extern const std::array<Conf_resources, 6> valid_conf_res;
 
@@ -78,7 +78,7 @@ struct Win_conf {
   std::optional<bool> is_resizable {};
   std::optional<bool> is_fullscreen {};
 
-  std::string describe() const;
+  [[nodiscard]] std::string describe() const;
 };
 
 struct Texture_conf {
@@ -89,7 +89,7 @@ struct Texture_conf {
   std::optional<SDL_BlendMode> text_blend_mode {};
   std::optional<remotemo::Color> text_color {};
 
-  std::string describe() const;
+  [[nodiscard]] std::string describe() const;
 };
 
 struct Texture_results {
@@ -98,7 +98,7 @@ struct Texture_results {
   SDL_Texture* font {nullptr};
   SDL_Texture* t_area {nullptr};
 
-  std::string describe() const;
+  [[nodiscard]] std::string describe() const;
 };
 extern const std::array<Texture_results, 10> all_texture_results;
 
@@ -134,7 +134,7 @@ struct Init_status {
   void attempt_setup_textures(Texture_results expected_results,
       const Texture_conf& texture_conf = {});
   void expected_cleanup();
-  bool check_a_texture_failed() const;
+  [[nodiscard]] bool check_a_texture_failed() const;
   void check_texture_cleanup() const;
 };
 

--- a/tests/src/test_init_helpers.cpp
+++ b/tests/src/test_init_helpers.cpp
@@ -40,7 +40,7 @@ SDL_Window* SDL_CreateWindow(
 {
   return mock_SDL.mock_CreateWindow(title, x, y, w, h, flags);
 }
-void SDL_GetWindowSize(SDL_Window* window, int* w, int* h)
+void SDL_GetWindowSize([[maybe_unused]] SDL_Window* window, int* w, int* h)
 { // Stub, not mock
   *w = 1000;
   *h = 1000;
@@ -84,7 +84,8 @@ SDL_Texture* IMG_LoadTexture(SDL_Renderer* renderer, const char* file_path)
   return mock_SDL.mock_LoadTexture(renderer, file_path);
 }
 int SDL_QueryTexture( // Stub, not mock
-    SDL_Texture* texture, Uint32* format, int* access, int* w, int* h)
+    [[maybe_unused]] SDL_Texture* texture, [[maybe_unused]] Uint32* format,
+    [[maybe_unused]] int* access, int* w, int* h)
 {
   *w = 1000;
   *h = 1000;

--- a/tests/src/test_io.cpp
+++ b/tests/src/test_io.cpp
@@ -21,6 +21,13 @@ constexpr int default_columns = 40;
 constexpr int default_lines = 24;
 
 // ----- Helper functions and struct ------
+namespace remotemo {
+Remotemo create_remotemo(std::unique_ptr<Engine> engine, const Config& config)
+{
+  return Remotemo(std::move(engine), config);
+}
+} // namespace remotemo
+
 struct Console_content {
   Console_content() = default;
   Console_content(int lines, const std::string def_line,
@@ -442,7 +449,7 @@ TEST_CASE("print() and print_at() functions", "[print]")
   auto config = setup(columns, lines);
   auto eng = remotemo::Engine::create(config);
   auto* engine = eng.get();
-  remotemo::Remotemo t {std::move(eng), config};
+  remotemo::Remotemo t = remotemo::create_remotemo(std::move(eng), config);
   t.set_text_delay(0);
   Console_content expected_content {lines, empty_line, normal_line};
   remotemo::Point expected_cursor_pos {0, 0};
@@ -552,7 +559,7 @@ TEST_CASE("print() - scroll set to true", "[print][scroll]")
   auto config = setup(columns, lines);
   auto eng = remotemo::Engine::create(config);
   auto* engine = eng.get();
-  remotemo::Remotemo t {std::move(eng), config};
+  remotemo::Remotemo t = remotemo::create_remotemo(std::move(eng), config);
   t.set_text_delay(0);
   REQUIRE(t.get_scrolling() == true);
   Console_content expected_content {lines, empty_line, normal_line};
@@ -621,7 +628,7 @@ TEST_CASE("print() - wrap set to character", "[print][wrap]")
   auto config = setup(columns, lines);
   auto eng = remotemo::Engine::create(config);
   auto* engine = eng.get();
-  remotemo::Remotemo t {std::move(eng), config};
+  remotemo::Remotemo t = remotemo::create_remotemo(std::move(eng), config);
   t.set_text_delay(0);
   REQUIRE(t.get_wrapping() == remotemo::Wrapping::character);
   Console_content expected_content {lines, empty_line, normal_line};
@@ -685,7 +692,7 @@ TEST_CASE("print() - scroll is on and wrap set to character",
   auto config = setup(columns, lines);
   auto eng = remotemo::Engine::create(config);
   auto* engine = eng.get();
-  remotemo::Remotemo t {std::move(eng), config};
+  remotemo::Remotemo t = remotemo::create_remotemo(std::move(eng), config);
   t.set_text_delay(0);
   REQUIRE(t.get_wrapping() == remotemo::Wrapping::character);
   Console_content expected_content {lines, empty_line, normal_line};
@@ -750,7 +757,7 @@ TEST_CASE("The 'inverse' setting should affect printing", "[print][inverse]")
   auto config = setup(columns, lines);
   auto eng = remotemo::Engine::create(config);
   auto* engine = eng.get();
-  remotemo::Remotemo t {std::move(eng), config};
+  remotemo::Remotemo t = remotemo::create_remotemo(std::move(eng), config);
   t.set_text_delay(0);
   Console_content expected_content {lines, empty_line, normal_line};
   remotemo::Point expected_cursor_pos {0, 0};
@@ -853,7 +860,7 @@ TEST_CASE("Inversed content should scroll the same way as the text",
   auto config = setup(columns, lines);
   auto eng = remotemo::Engine::create(config);
   auto* engine = eng.get();
-  remotemo::Remotemo t {std::move(eng), config};
+  remotemo::Remotemo t = remotemo::create_remotemo(std::move(eng), config);
   t.set_text_delay(0);
   Console_content expected_content {lines, empty_line, normal_line};
   remotemo::Point expected_cursor_pos {0, 0};

--- a/tests/src/test_io.cpp
+++ b/tests/src/test_io.cpp
@@ -30,8 +30,8 @@ Remotemo create_remotemo(std::unique_ptr<Engine> engine, const Config& config)
 
 struct Console_content {
   Console_content() = default;
-  Console_content(int lines, const std::string def_line,
-      const std::deque<bool> def_is_line_inv)
+  Console_content(int lines, const std::string& def_line,
+      const std::deque<bool>& def_is_line_inv)
       : text(std::deque<std::string>(lines, def_line)),
         is_inv(std::deque<std::deque<bool>>(lines, def_is_line_inv))
   {}
@@ -53,7 +53,7 @@ std::string get_line_str(int line_num, const remotemo::Engine* engine)
 void compare_to_content(const std::deque<std::string>& expected_text_content,
     const remotemo::Engine* engine)
 {
-  int max_line = expected_text_content.size();
+  auto max_line = expected_text_content.size();
   for (int i = 0; i < max_line; i++) {
     INFO("Checking line " << i);
     std::string line_content = get_line_str(i, engine);
@@ -76,7 +76,7 @@ void compare_to_content(
     const std::deque<std::deque<bool>>& expected_is_content_inv,
     const remotemo::Engine* engine)
 {
-  int max_line = expected_is_content_inv.size();
+  auto max_line = expected_is_content_inv.size();
   for (int i = 0; i < max_line; i++) {
     INFO("Checking line " << i);
     std::deque<bool> line_inverse = get_line_is_inverse(i, engine);
@@ -468,7 +468,7 @@ TEST_CASE("print() and print_at() functions", "[print]")
       REQUIRE(t.print(text) == 0);
       expected_content.text[expected_cursor_pos.y].replace(
           expected_cursor_pos.x, text.size(), text);
-      expected_cursor_pos.x += text.size();
+      expected_cursor_pos.x += static_cast<int>(text.size());
       check_status(expected_content, expected_cursor_pos, engine);
     }
     SECTION("Printing \"\\n\" should move cursor to beginning of next line")
@@ -501,7 +501,7 @@ TEST_CASE("print() and print_at() functions", "[print]")
     for (const auto& text : {"Foo!!!"s, "_bar_"s, "spam"s}) {
       REQUIRE(t.print_at(5, 2, text) == 0);
       expected_content.text[2].replace(5, text.size(), text);
-      expected_cursor_pos.x = 5 + text.size();
+      expected_cursor_pos.x = 5 + static_cast<int>(text.size());
       expected_cursor_pos.y = 2;
       check_status(expected_content, expected_cursor_pos, engine);
     }
@@ -534,7 +534,7 @@ TEST_CASE("print() with delay", "[print][pause]")
     t->set_cursor(0, 0);
     t->set_text_delay(delay_ms);
     for (const auto& text : {"Foo!"s, "_bar_"s, "<spam>"s}) {
-      int expected_duration = delay_ms * text.size();
+      int expected_duration = delay_ms * static_cast<int>(text.size());
       auto start = std::chrono::high_resolution_clock::now();
       t->print(text);
       auto end = std::chrono::high_resolution_clock::now();
@@ -603,7 +603,7 @@ TEST_CASE("print() - scroll set to true", "[print][scroll]")
       expected_content.text.push_back(empty_line);
       expected_content.text[lines - 1].replace(
           print_to_pos.x, text.size(), text);
-      expected_cursor_pos.x = print_to_pos.x + text.size();
+      expected_cursor_pos.x = print_to_pos.x + static_cast<int>(text.size());
       expected_cursor_pos.y = lines - 1;
       check_status(expected_content, expected_cursor_pos, engine);
     }
@@ -667,7 +667,7 @@ TEST_CASE("print() - wrap set to character", "[print][wrap]")
       REQUIRE(t.print(text) == 0);
       expected_content.text[expected_cursor_pos.y].replace(
           expected_cursor_pos.x, text.size(), text);
-      expected_cursor_pos.x += text.size();
+      expected_cursor_pos.x += static_cast<int>(text.size());
       check_status(expected_content, expected_cursor_pos, engine);
       REQUIRE(t.print(std::string(text.size() + count, '\b') +
                       "this should be ignored") == -2);
@@ -775,7 +775,7 @@ TEST_CASE("The 'inverse' setting should affect printing", "[print][inverse]")
     t.set_inverse(true);
 
     for (const auto& text : {"   "s, "Hello"s, "- there -"s}) {
-      int col = (columns - text.size()) / 2;
+      int col = (columns - static_cast<int>(text.size())) / 2;
       int& line = expected_cursor_pos.y;
       t.set_cursor_column(col);
       t.print(text + "\n");
@@ -793,7 +793,7 @@ TEST_CASE("The 'inverse' setting should affect printing", "[print][inverse]")
         t.set_cursor(0, 0);
         t.print(text);
         expected_cursor_pos.x = 0;
-        expected_cursor_pos.y = text.size();
+        expected_cursor_pos.y = static_cast<int>(text.size());
         check_status(expected_content, expected_cursor_pos, engine);
       }
     }
@@ -805,7 +805,7 @@ TEST_CASE("The 'inverse' setting should affect printing", "[print][inverse]")
       expected_cursor_pos.y = 0;
       t.set_inverse(false);
       for (const auto& text : {" "s, "Allo"s, "====="s}) {
-        int col = (columns - text.size()) / 2;
+        int col = (columns - static_cast<int>(text.size())) / 2;
         int& line = expected_cursor_pos.y;
         t.set_cursor_column(col);
         t.print(text + "\n");
@@ -869,7 +869,7 @@ TEST_CASE("Inversed content should scroll the same way as the text",
 
   for (const auto& text : {"   "s, "Hello"s, "- there -"s, "          "s,
            "start"s, "....scrolling!"s, ""s, ""s, "ok"s}) {
-    int col = (columns - text.size()) / 2;
+    int col = (columns - static_cast<int>(text.size())) / 2;
     int& line = expected_cursor_pos.y;
     t.set_cursor_column(col);
     t.print(text + "\n");


### PR DESCRIPTION
Mostly fixing clang-tidy warnings, simplify a bit and make private a constructor that is only needed for the unit tests