### PR TITLE
Fix window not refreshed when waiting for get_key

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(remotemo
     VERSION 0.1.0
     LANGUAGES CXX
 )
-set(remotemo_PRE_RELEASE_LABEL beta.6)
+set(remotemo_PRE_RELEASE_LABEL beta.7)
 
 if(NOT remotemo_PRE_RELEASE_LABEL STREQUAL "")
     set(remotemo_VERSION

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -335,6 +335,7 @@ Key Engine::get_key()
       continue;
     }
     if (handle_standard_event(event)) {
+      render_window();
       continue;
     }
     if (event.type == SDL_KEYDOWN) {


### PR DESCRIPTION
This fixes that bug, but it's even more obvious that engine.cpp needs some refactoring and/or redesigning.