### PR TITLE
Fix content not updating correctly (e.g. when minimized)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(remotemo
     VERSION 0.1.0
     LANGUAGES CXX
 )
-set(remotemo_PRE_RELEASE_LABEL beta.8)
+set(remotemo_PRE_RELEASE_LABEL rc.1)
 
 if(NOT remotemo_PRE_RELEASE_LABEL STREQUAL "")
     set(remotemo_VERSION

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -340,10 +340,12 @@ Key Engine::get_key()
     }
     if (event.type == SDL_KEYDOWN) {
       // TODO remove this debugging logging:
+      /*
       SDL_Log("Physical %s key (%d) acting as %s key (%d)",
           SDL_GetScancodeName(event.key.keysym.scancode),
           event.key.keysym.scancode, SDL_GetKeyName(event.key.keysym.sym),
           event.key.keysym.sym);
+      */
       auto key = Keyboard::scancode_to_key(event.key.keysym.scancode);
       if (!key) {
         continue;
@@ -356,7 +358,6 @@ Key Engine::get_key()
 void Engine::main_loop_once()
 {
   throw_if_window_closed();
-  // SDL_Log("Main loop once!");
   SDL_Event event;
   while (SDL_PollEvent(&event) != 0) {
     handle_standard_event(event);
@@ -402,7 +403,6 @@ bool Engine::handle_window_event(const SDL_Event& event)
       }
       break;
     case SDL_WINDOWEVENT:
-      SDL_Log("Window event: %d", event.window.event);
       switch (event.window.event) {
         case SDL_WINDOWEVENT_LEAVE:
         case SDL_WINDOWEVENT_FOCUS_LOST:
@@ -416,13 +416,8 @@ bool Engine::handle_window_event(const SDL_Event& event)
         case SDL_WINDOWEVENT_SIZE_CHANGED:
           m_window->refresh_local_size();
           refresh_screen_display_settings();
-          SDL_Log("Size changed");
-          return true;
-        case SDL_WINDOWEVENT_MINIMIZED:
-          SDL_Log("-----Minimized-----");
           return true;
         default:
-          SDL_Log("Unhandled window event: %d", event.window.event);
           return true;
       }
     default:
@@ -455,28 +450,20 @@ void Engine::close_window()
 void Engine::render_window()
 {
   if (m_window->had_window_event()) {
-    SDL_Log("== window had event ==");
     m_text_display->set_texture_refresh_needed(true);
     m_window->set_had_window_event(false);
     m_window->refresh_local_flags();
-    if (m_window->is_visible()) {
-      SDL_Log("Window is <<<VISIBLE>>>");
-    }
   }
   if (!m_window->is_visible()) {
-    SDL_Log("Window is ===HIDDEN=== (or minimized)");
     return;
   }
   if (m_text_display->is_texture_refresh_needed()) {
-    SDL_Log("++++ testure refresh needed +++");
     m_text_display->refresh_texture();
   }
   m_text_display->update_cursor();
   if (!m_text_display->has_texture_changed()) {
-    SDL_Log("|||| No change to texture ||||");
     return;
   }
-  SDL_Log(">>>>>>>>>>>>>>>>>>> rendering .....");
   auto* renderer = m_renderer->res();
   ::SDL_SetRenderTarget(renderer, nullptr);
   ::SDL_RenderClear(renderer);

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -402,18 +402,43 @@ bool Engine::handle_window_event(const SDL_Event& event)
       }
       break;
     case SDL_WINDOWEVENT:
+      if (m_window->is_minimized()) {
+        SDL_Log("Minimized is <<<true>>>");
+      } else {
+        SDL_Log("Minimized is FALSE");
+      }
+      SDL_Log("Window event: %d", event.window.event);
       switch (event.window.event) {
         case SDL_WINDOWEVENT_SIZE_CHANGED:
           m_window->refresh_local_size();
           refresh_screen_display_settings();
+          SDL_Log("Size changed");
+          return true;
+        case SDL_WINDOWEVENT_MINIMIZED:
+          m_window->set_minimized(true);
+          SDL_Log("Minimized set to true");
+          return true;
+        case SDL_WINDOWEVENT_SHOWN:
+          unminimize_window();
+          SDL_Log("SHOWN. Minimized set to false");
           return true;
         default:
+          SDL_Log("Unhandled window event: %d", event.window.event);
           break;
       }
     default:
       break;
   }
   return false;
+}
+
+void Engine::unminimize_window()
+{
+  if (!m_window->is_minimized()) {
+    return;
+  }
+  m_window->set_minimized(false);
+  m_text_display->refresh_display();
 }
 
 void Engine::user_closes_window()
@@ -440,6 +465,9 @@ void Engine::close_window()
 void Engine::render_window()
 {
   m_text_display->update_cursor();
+  if (m_window->is_minimized()) {
+    return;
+  }
   auto* renderer = m_renderer->res();
   ::SDL_SetRenderTarget(renderer, nullptr);
   ::SDL_RenderClear(renderer);

--- a/src/engine.hpp
+++ b/src/engine.hpp
@@ -111,6 +111,7 @@ protected:
   void refresh_screen_display_settings();
   void throw_if_window_closed() const;
   void user_closes_window();
+  void unminimize_window();
 
 private:
   Main_SDL_handler m_main_sdl_handler;

--- a/src/engine.hpp
+++ b/src/engine.hpp
@@ -111,7 +111,6 @@ protected:
   void refresh_screen_display_settings();
   void throw_if_window_closed() const;
   void user_closes_window();
-  void unminimize_window();
 
 private:
   Main_SDL_handler m_main_sdl_handler;

--- a/src/text_display.cpp
+++ b/src/text_display.cpp
@@ -127,7 +127,6 @@ void Text_display::refresh_texture()
   }
   m_is_texture_refresh_needed = false;
   m_is_cursor_updated = false;
-  //update_cursor();
 }
 
 void Text_display::display_char_at(

--- a/src/text_display.cpp
+++ b/src/text_display.cpp
@@ -118,6 +118,8 @@ void Text_display::scroll_up_one_line()
 
 void Text_display::refresh_texture()
 {
+  SDL_SetRenderTarget(m_renderer, res());
+  SDL_RenderClear(m_renderer);
   for (int line = 0; line < m_lines; line++) {
     for (int column = 0; column < m_columns; column++) {
       auto& content = m_display_content[line][column];

--- a/src/text_display.cpp
+++ b/src/text_display.cpp
@@ -132,6 +132,19 @@ void Text_display::scroll_up_one_line()
       m_text_to_screen_color.green, m_text_to_screen_color.blue);
 }
 
+void Text_display::refresh_display()
+{
+  for (int line = 0; line < m_lines; line++) {
+    for (int column = 0; column < m_columns; column++) {
+      auto& content = m_display_content[line][column];
+      display_char_at(
+          content.character, content.is_inversed, Point {column, line});
+    }
+  }
+  m_is_cursor_updated = false;
+  update_cursor();
+}
+
 void Text_display::display_char_at(
     int character, bool is_output_inversed, const Point& pos)
 {

--- a/src/text_display.cpp
+++ b/src/text_display.cpp
@@ -102,37 +102,21 @@ void Text_display::clear_line(int line)
   SDL_RenderCopy(m_renderer, m_font.res(), &space_bitmap, &target_area);
 
   m_display_content[line] = m_empty_line;
-
+  m_has_texture_changed = true;
+  if (line == m_cursor_pos.y) {
+    m_is_cursor_updated = false;
+  }
   SDL_SetRenderTarget(m_renderer, nullptr);
 }
 
 void Text_display::scroll_up_one_line()
 {
-  constexpr Color white {255, 255, 255};
-  SDL_SetRenderTarget(m_renderer, res());
-  SDL_SetTextureBlendMode(res(), SDL_BLENDMODE_NONE);
-  SDL_SetTextureColorMod(res(), white.red, white.green, white.blue);
-
-  int line_length = texture_size().width - 2;
-  int line_height = m_font.char_height();
-  int scrolling_lines_height = texture_size().height - 2 - line_height;
-  SDL_Rect area_to_be_moved = {
-      1, 1 + line_height, line_length, scrolling_lines_height};
-  SDL_Rect target_area = {1, 1, line_length, scrolling_lines_height};
-  SDL_RenderCopy(m_renderer, res(), &area_to_be_moved, &target_area);
-
-  m_display_content.pop_front();
   m_display_content.push_back(m_empty_line);
-
-  clear_line(m_lines - 1);
-
-  SDL_SetRenderTarget(m_renderer, nullptr);
-  SDL_SetTextureBlendMode(res(), m_blend_to_screen_mode);
-  SDL_SetTextureColorMod(res(), m_text_to_screen_color.red,
-      m_text_to_screen_color.green, m_text_to_screen_color.blue);
+  m_display_content.pop_front();
+  m_is_texture_refresh_needed = true;
 }
 
-void Text_display::refresh_display()
+void Text_display::refresh_texture()
 {
   for (int line = 0; line < m_lines; line++) {
     for (int column = 0; column < m_columns; column++) {
@@ -141,8 +125,9 @@ void Text_display::refresh_display()
           content.character, content.is_inversed, Point {column, line});
     }
   }
+  m_is_texture_refresh_needed = false;
   m_is_cursor_updated = false;
-  update_cursor();
+  //update_cursor();
 }
 
 void Text_display::display_char_at(
@@ -165,6 +150,7 @@ void Text_display::display_char_at(
       m_font.char_height()};
   SDL_RenderCopy(
       m_renderer, m_font.res(), &bitmap_char_area, &display_target_area);
+  m_has_texture_changed = true;
   SDL_SetRenderTarget(m_renderer, nullptr);
 }
 

--- a/src/text_display.hpp
+++ b/src/text_display.hpp
@@ -48,7 +48,23 @@ public:
   void set_char_at_cursor(int character);
   void scroll_up_one_line();
   void clear_line(int line);
-  void refresh_display();
+  void refresh_texture();
+  void set_texture_refresh_needed(bool refresh_needed)
+  {
+    m_is_texture_refresh_needed = refresh_needed;
+  }
+  [[nodiscard]] bool is_texture_refresh_needed() const
+  {
+    return m_is_texture_refresh_needed;
+  }
+  void set_texture_changed(bool has_changed)
+  {
+    m_has_texture_changed = has_changed;
+  }
+  [[nodiscard]] bool has_texture_changed() const
+  {
+    return m_has_texture_changed;
+  }
 
 private:
   void display_char_at(
@@ -66,6 +82,8 @@ private:
   bool m_is_cursor_visible {true};
   bool m_is_cursor_updated {false};
   bool m_is_output_inversed {false};
+  bool m_is_texture_refresh_needed {false};
+  bool m_has_texture_changed {false};
   static constexpr int max_ascii_value {127};
   static constexpr int bitmap_char_per_line {16};
   static constexpr Point space_position {0, 2};

--- a/src/text_display.hpp
+++ b/src/text_display.hpp
@@ -48,6 +48,7 @@ public:
   void set_char_at_cursor(int character);
   void scroll_up_one_line();
   void clear_line(int line);
+  void refresh_display();
 
 private:
   void display_char_at(

--- a/src/text_display.hpp
+++ b/src/text_display.hpp
@@ -24,8 +24,6 @@ public:
       const Text_area_config& text_area_config) noexcept
       : Texture(texture, true), m_renderer(renderer), m_font(std::move(font)),
         m_columns(text_area_config.columns), m_lines(text_area_config.lines),
-        m_blend_to_screen_mode(text_area_config.blend_mode),
-        m_text_to_screen_color(text_area_config.color),
         m_empty_line(m_columns), m_display_content(m_lines, m_empty_line)
   {}
 
@@ -74,8 +72,6 @@ private:
   Font m_font;
   int m_columns;
   int m_lines;
-  SDL_BlendMode m_blend_to_screen_mode;
-  Color m_text_to_screen_color;
   std::vector<Display_square> m_empty_line;
   std::deque<std::vector<Display_square>> m_display_content;
   Point m_cursor_pos {0, 0};

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -39,6 +39,8 @@ void Window::refresh_local_flags()
 {
   auto window_flags = SDL_GetWindowFlags(res());
   m_is_fullscreen = ((window_flags & SDL_WINDOW_FULLSCREEN) != 0);
+  m_is_visible =
+      ((window_flags & (SDL_WINDOW_HIDDEN | SDL_WINDOW_MINIMIZED)) == 0);
 }
 
 void Window::set_fullscreen(bool do_make_fullscreen)

--- a/src/window.hpp
+++ b/src/window.hpp
@@ -21,17 +21,22 @@ public:
   void refresh_local_size();
   void refresh_local_flags();
   void set_fullscreen(bool do_make_fullscreen);
-  void set_minimized(bool is_minimized) {m_is_minimized = is_minimized; }
+  void set_had_window_event(bool had_window_event)
+  {
+    m_had_window_event = had_window_event;
+  }
   [[nodiscard]] const Size& size() const { return m_size; }
   [[nodiscard]] bool is_fullscreen() const { return m_is_fullscreen; }
-  [[nodiscard]] bool is_minimized() const { return m_is_minimized; }
+  [[nodiscard]] bool is_visible() const { return m_is_visible; }
+  [[nodiscard]] bool had_window_event() const { return m_had_window_event; }
 
 private:
   bool setup(const Window_config& window_config);
 
   Size m_size {0, 0};
   bool m_is_fullscreen {false};
-  bool m_is_minimized {false};
+  bool m_is_visible {true};
+  bool m_had_window_event {false};
 };
 } // namespace remotemo
 #endif // REMOTEMO_SRC_WINDOW_HPP

--- a/src/window.hpp
+++ b/src/window.hpp
@@ -21,14 +21,17 @@ public:
   void refresh_local_size();
   void refresh_local_flags();
   void set_fullscreen(bool do_make_fullscreen);
+  void set_minimized(bool is_minimized) {m_is_minimized = is_minimized; }
   [[nodiscard]] const Size& size() const { return m_size; }
   [[nodiscard]] bool is_fullscreen() const { return m_is_fullscreen; }
+  [[nodiscard]] bool is_minimized() const { return m_is_minimized; }
 
 private:
   bool setup(const Window_config& window_config);
 
   Size m_size {0, 0};
   bool m_is_fullscreen {false};
+  bool m_is_minimized {false};
 };
 } // namespace remotemo
 #endif // REMOTEMO_SRC_WINDOW_HPP


### PR DESCRIPTION
Fix #60, #61 and #16

Originally thought to just be a question of fixing #16 by refreshing the texture each time the window is unminimized.

Instead could to fix all those issues at once by:

- [x] adding a flag to text_display that can be set when the texture "might" need to be refreshed (i.e. when the content scrolls up and when _any_ window event happens).
- [x] check that flag each time the window is going to be refreshed. And if set, then refresh the texture first before rendering to the window (and reset the flag back to `off`).
- [x] but first, if there was a window event, check if the current state of the window is minimized (or hidden) and set a flag to reflect that. While that flag is set, skip **_any_** rendering (we should be able to assume that this state doesn't change unless there was a window event).
Strictly speaking, this might not be needed to fix those bugs but should be a simple way to make the rendering more efficient.